### PR TITLE
feat: output crate-feature matrix instead of features list

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,10 +23,12 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
       - run: npm install
       - run: npm run check
+
   Test:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
+    outputs:
+      roas-matrix: ${{ steps.roas.outputs.matrix }}
+      nuspec-matrix: ${{ steps.nuspec-rs.outputs.matrix }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
 
@@ -39,11 +41,9 @@ jobs:
         uses: ./
         with:
           manifest-path: "./nuspec-rs/Cargo.toml"
-      - run: echo "Crates - ${{ steps.nuspec-rs.outputs.crates }}"
-      - run: echo "Publish - ${{ steps.nuspec-rs.outputs.publish }}"
-      - run: echo "Features - ${{ steps.nuspec-rs.outputs.features }}"
-      - run: echo "Nuspec features - ${{ toJSON(fromJSON(steps.nuspec-rs.outputs.features).nuspec) }}"
-      - run: echo "Nuspec-test features - ${{ toJSON(fromJSON(steps.nuspec-rs.outputs.features).nuspec-test) }}"
+      - run: echo "Packages - ${{ steps.nuspec-rs.outputs.packages }}"
+      - run: echo "To Publish - ${{ steps.nuspec-rs.outputs.publish }}"
+      - run: echo "Matrix - ${{ steps.nuspec-rs.outputs.matrix }}"
 
       - name: Checkout roas as a test project
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
@@ -54,10 +54,38 @@ jobs:
         uses: ./
         with:
           manifest-path: "./roas/Cargo.toml"
-      - run: echo "Crates - ${{ steps.roas.outputs.crates }}"
-      - run: echo "Publish - ${{ steps.roas.outputs.publish }}"
-      - run: echo "Features - ${{ steps.roas.outputs.features }}"
-      - run: echo "Roas features - ${{ toJSON(fromJSON(steps.roas.outputs.features).roas) }}"
+      - run: echo "Packages - ${{ steps.roas.outputs.packages }}"
+      - run: echo "To Publish - ${{ steps.roas.outputs.publish }}"
+      - run: echo "Matrix - ${{ steps.roas.outputs.matrix }}"
 
-      - uses: ./
+      - name: Should fail
+        uses: ./
         continue-on-error: true
+
+  Roas:
+    runs-on: ubuntu-latest
+    needs: Test
+    strategy:
+      matrix:
+        args: ${{ fromJson(needs.Test.outputs.roas-matrix) }}
+    steps:
+      - name: Checkout roas as a test project
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
+        with:
+          repository: sv-tools/roas
+      - name: Run tests
+        run: cargo test ${{ matrix.args }} --no-default-features --no-fail-fast --verbose
+
+  Nuspec:
+    runs-on: ubuntu-latest
+    needs: Test
+    strategy:
+      matrix:
+        args: ${{ fromJson(needs.Test.outputs.nuspec-matrix) }}
+    steps:
+      - name: Checkout nuspec-rs as a test project
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
+        with:
+          repository: sv-tools/nuspec-rs
+      - name: Run tests
+        run: cargo test ${{ matrix.args }} --no-default-features --no-fail-fast --verbose

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Rust Metadata Action"
-description: "GitHub action to retrieve metadata, including crates, features, and other relevant information of the Rust project"
+description: "GitHub action to retrieve metadata, including packages, features, and other relevant information of the Rust project"
 branding:
   icon: "code"
   color: "red"
@@ -11,12 +11,12 @@ inputs:
 outputs:
   metadata:
     description: "Raw Metadata"
-  crates:
-    description: "List of crates: [foo, bar, baz]"
+  packages:
+    description: "List of packages: [foo, bar, baz]"
   publish:
-    description: "List of crates that can be published: [foo, bar]"
-  features:
-    description: "List of features: {foo: [bar, baz], bar: [baz]}"
+    description: "List of packages that can be published: [foo, bar]"
+  matrix:
+    description: "List of packages and their features: [--package=foo, --package=bar --features=foo, --package=bar --features=bar]"
 runs:
   using: node24
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -40,21 +40,28 @@ async function run() {
 function setActionOutput(metadata) {
   (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput)("metadata", JSON.stringify(metadata));
   if (metadata.hasOwnProperty("packages")) {
-    let allCrates = [];
-    let cratesToPublish = [];
-    let features = {};
+    let allPackages = [];
+    let packagesToPublish = [];
+    let matrix = [];
     metadata.packages.forEach((pkg) => {
-      allCrates.push(pkg.name);
+      allPackages.push(pkg.name);
       if (pkg.hasOwnProperty("publish") && pkg.publish !== false) {
-        cratesToPublish.push(pkg.name);
+        packagesToPublish.push(pkg.name);
       }
       if (pkg.hasOwnProperty("features")) {
-        features[pkg.name] = Object.getOwnPropertyNames(pkg.features);
+        const names = Object.getOwnPropertyNames(pkg.features);
+        if (names.length === 0) {
+          matrix.push(`--package=${pkg.name}`);
+        } else {
+          names.forEach((feature) => {
+            matrix.push(`--package=${pkg.name} --features=${feature}`);
+          });
+        }
       }
     });
-    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput)("crates", JSON.stringify(allCrates));
-    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput)("publish", JSON.stringify(cratesToPublish));
-    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput)("features", JSON.stringify(features));
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput)("packages", JSON.stringify(allPackages));
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput)("publish", JSON.stringify(packagesToPublish));
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput)("matrix", JSON.stringify(matrix));
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -27,21 +27,28 @@ async function run() {
 function setActionOutput(metadata) {
   setOutput("metadata", JSON.stringify(metadata));
   if (metadata.hasOwnProperty("packages")) {
-    let allCrates = [];
-    let cratesToPublish = [];
-    let features = {};
+    let allPackages = [];
+    let packagesToPublish = [];
+    let matrix = [];
     metadata.packages.forEach((pkg) => {
-      allCrates.push(pkg.name);
+      allPackages.push(pkg.name);
       if (pkg.hasOwnProperty("publish") && pkg.publish !== false) {
-        cratesToPublish.push(pkg.name);
+        packagesToPublish.push(pkg.name);
       }
       if (pkg.hasOwnProperty("features")) {
-        features[pkg.name] = Object.getOwnPropertyNames(pkg.features);
+        const names = Object.getOwnPropertyNames(pkg.features);
+        if (names.length === 0) {
+          matrix.push(`--package=${pkg.name}`);
+        } else {
+          names.forEach((feature) => {
+            matrix.push(`--package=${pkg.name} --features=${feature}`);
+          });
+        }
       }
     });
-    setOutput("crates", JSON.stringify(allCrates));
-    setOutput("publish", JSON.stringify(cratesToPublish));
-    setOutput("features", JSON.stringify(features));
+    setOutput("packages", JSON.stringify(allPackages));
+    setOutput("publish", JSON.stringify(packagesToPublish));
+    setOutput("matrix", JSON.stringify(matrix));
   }
 }
 


### PR DESCRIPTION
Replace the previous per-crate features object with a flat matrix
representation of crate/feature pairs and update all callers.

- action.yml: rename 'features' output to 'matrix' and update the
  description to reflect [{crate, feature}] entries.
- dist/index.js and index.js: build an array of {crate, feature} objects
  instead of mapping crate -> features array; set output "matrix".
- .github/workflows/checks.yml: update workflow echo lines to read the
  new "Matrix" output and reword publish echoes to "To Publish".