### PR TITLE
Filter publish output by registry version (cargo info)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -140,11 +140,11 @@ jobs:
         # workspace member declaration order, but feature order is alphabetical.
         # Sorting both sides keeps the assertion stable across cargo versions.
         run: |
-          jq -ne --argjson got "$PACKAGES" '$got | sort == ["app","feature-lib","private-lib"]' \
+          jq -ne --argjson got "$PACKAGES" '$got | sort == ["feature-lib","private-lib","rma-fixture-app"]' \
             || { echo "packages: $PACKAGES"; exit 1; }
-          jq -ne --argjson got "$PUBLISH" '$got | sort == ["app","feature-lib"]' \
+          jq -ne --argjson got "$PUBLISH" '$got | sort == ["feature-lib","rma-fixture-app"]' \
             || { echo "publish: $PUBLISH"; exit 1; }
-          jq -ne --argjson got "$MATRIX" '$got | sort == ["--package=app","--package=feature-lib --features=bar","--package=feature-lib --features=default","--package=feature-lib --features=foo","--package=private-lib"]' \
+          jq -ne --argjson got "$MATRIX" '$got | sort == ["--package=feature-lib --features=bar","--package=feature-lib --features=default","--package=feature-lib --features=foo","--package=private-lib","--package=rma-fixture-app"]' \
             || { echo "matrix: $MATRIX"; exit 1; }
           [ "$RUST_VERSION" = '1.90' ] || { echo "rust-version: $RUST_VERSION"; exit 1; }
           [ "$EDITION" = '2024' ] || { echo "edition: $EDITION"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ matrix).
 
 - `metadata`: Raw cargo metadata JSON.
 - `packages`: JSON array (string) of package names, e.g. `["foo","bar"]`.
-- `publish`: JSON array (string) of packages that can be published.
+- `publish`: JSON array (string) of packages whose local `version` is strictly newer than the version on the registry — i.e. the set that actually needs to be published. The action runs `cargo info` for each publishable candidate and compares versions per semver. Packages declared `publish = false` are always excluded; packages not yet on the registry are included (first publish); packages restricted to a private registry via `publish = ["my-registry"]` are queried against that registry.
 - `matrix`: JSON array (string) of command-line fragments suitable for use as a job matrix, e.g.
   `["--package=foo","--package=bar --features=foo"]`
 - `rust-version`: Workspace MSRV — the highest `rust-version` declared by any package, compared numerically (so `1.10`
@@ -112,6 +112,10 @@ jobs:
     additional bare `--package=<name>` row in this case. The intent is to drive `cargo {test,build}` per feature
     rather than to also test "no features".
   - `publish = false` packages still appear in `packages` but are excluded from `publish`.
+- `publish` filtering:
+  - Each publishable candidate is checked with `cargo info`. Only packages whose Cargo.toml `version` is strictly greater than the latest on the registry are emitted.
+  - Crates not yet on the registry (cargo info reports "could not find …") are included so a first-time publish goes through.
+  - If `cargo info` fails for any other reason (network, registry outage), that candidate is logged as a warning and skipped — the action errs on the side of *not* republishing rather than spuriously emitting a stale package.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ outputs:
   packages:
     description: 'JSON-encoded array of every package name in the workspace. Example: `["foo","bar"]`.'
   publish:
-    description: 'JSON-encoded array of package names that are publishable. Packages declared `publish = false` are excluded; packages restricted to specific registries are included. Example: `["foo","bar"]`.'
+    description: 'JSON-encoded array of package names that need to be published — i.e. their local `version` is strictly newer than what is on the registry. The action runs `cargo info` for each publishable candidate and compares versions per semver. Packages declared `publish = false` are always excluded; packages not yet on the registry are included (first publish); packages whose registry version is equal or newer are skipped. Packages restricted to a specific registry via `publish = ["my-registry"]` are queried against that registry. Example: `["foo","bar"]`.'
   matrix:
     description: 'JSON-encoded array of cargo argument strings — one entry per package, or one per feature for packages that declare features. Intended for `strategy.matrix`. Example: `["--package=foo","--package=bar --features=full"]`.'
   rust-version:

--- a/dist/index.js
+++ b/dist/index.js
@@ -28232,7 +28232,7 @@ async function asyncPool(limit, items, worker) {
     while (true) {
       const i = cursor++;
       if (i >= items.length) return;
-      results[i] = await worker(items[i], i);
+      results[i] = await worker(items[i]);
     }
   };
   const workerCount = Math.max(1, Math.min(limit, items.length));

--- a/dist/index.js
+++ b/dist/index.js
@@ -27976,7 +27976,7 @@ __webpack_async_result__();
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
 /* harmony export */   eF: () => (/* binding */ run)
 /* harmony export */ });
-/* unused harmony exports ensureToolchain, runCargoMetadata, parseMetadata, writeOutputs */
+/* unused harmony exports ensureToolchain, runCargoMetadata, compareSemver, parseCargoInfoVersion, getPublishedVersion, parseMetadata, filterPublishable, writeOutputs */
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(2698);
 /* harmony import */ var child_process__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(5317);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(6928);
@@ -28086,16 +28086,120 @@ function compareVersion(a, b) {
   return 0;
 }
 
+// Full semver compare per https://semver.org §11. Returns negative if a < b,
+// 0 if equal in precedence, positive if a > b. Build metadata (`+...`) is
+// ignored; prerelease segments (`-...`) are compared per spec: numeric < non-
+// numeric, and a version with a prerelease is lower than the same without.
+function compareSemver(a, b) {
+  const stripBuild = (v) => v.split("+")[0];
+  const split = (v) => {
+    const s = stripBuild(v);
+    const i = s.indexOf("-");
+    return i === -1
+      ? { main: s, pre: null }
+      : { main: s.slice(0, i), pre: s.slice(i + 1) };
+  };
+  const sa = split(a);
+  const sb = split(b);
+  const parse = (m) => m.split(".").map((p) => parseInt(p, 10) || 0);
+  const av = parse(sa.main);
+  const bv = parse(sb.main);
+  for (let i = 0; i < 3; i++) {
+    const diff = (av[i] ?? 0) - (bv[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  if (sa.pre === null && sb.pre === null) return 0;
+  if (sa.pre === null) return 1;
+  if (sb.pre === null) return -1;
+  const ap = sa.pre.split(".");
+  const bp = sb.pre.split(".");
+  for (let i = 0; i < Math.max(ap.length, bp.length); i++) {
+    if (ap[i] === undefined) return -1;
+    if (bp[i] === undefined) return 1;
+    const aNum = /^\d+$/.test(ap[i]);
+    const bNum = /^\d+$/.test(bp[i]);
+    if (aNum && bNum) {
+      const d = parseInt(ap[i], 10) - parseInt(bp[i], 10);
+      if (d !== 0) return d;
+    } else if (aNum !== bNum) {
+      // Numeric identifiers always have lower precedence than alphanumeric.
+      return aNum ? -1 : 1;
+    } else {
+      const c = ap[i] < bp[i] ? -1 : ap[i] > bp[i] ? 1 : 0;
+      if (c !== 0) return c;
+    }
+  }
+  return 0;
+}
+
+// Pulls the published version from cargo info's stdout.
+function parseCargoInfoVersion(stdout) {
+  const m = stdout.match(/^version:\s*(\S+)/im);
+  return m ? m[1] : null;
+}
+
+// Run `cargo info <name>` and return the latest published version, or null
+// if the package isn't on the registry yet (first publish). Other failures
+// reject so callers can surface them.
+function getPublishedVersion(pkgName, cwd, registry) {
+  return new Promise((resolve, reject) => {
+    const args = ["info", pkgName];
+    if (registry) {
+      args.push("--registry", registry);
+    }
+    const cmd = (0,child_process__WEBPACK_IMPORTED_MODULE_1__.spawn)("cargo", args, { cwd });
+
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    cmd.stdout.on("data", (chunk) => stdoutChunks.push(chunk));
+    cmd.stderr.on("data", (chunk) => stderrChunks.push(chunk));
+
+    cmd.on("error", (error) => {
+      reject(new Error(`cargo info failed to spawn: ${error.message}`));
+    });
+
+    cmd.on("close", (code) => {
+      const stdout = Buffer.concat(stdoutChunks).toString();
+      const stderr = Buffer.concat(stderrChunks).toString();
+      if (code !== 0) {
+        if (/could not find/i.test(stderr)) {
+          resolve(null);
+          return;
+        }
+        reject(
+          new Error(
+            `cargo info ${pkgName} failed (exit code ${code})` +
+              (stderr.trim() ? `: ${stderr.trim()}` : ""),
+          ),
+        );
+        return;
+      }
+      resolve(parseCargoInfoVersion(stdout));
+    });
+  });
+}
+
 function parseMetadata(metadata) {
   const packages = [];
-  const publish = [];
+  const publishCandidates = [];
   const matrix = [];
   let rustVersion = null;
   let edition = null;
   for (const pkg of metadata.packages ?? []) {
     packages.push(pkg.name);
     if (isPublishable(pkg)) {
-      publish.push(pkg.name);
+      // `publish = ["my-registry", ...]` restricts where the crate may go;
+      // pick the first entry as the registry to query. `publish = null`
+      // (unrestricted) maps to the default registry, so leave it unset.
+      const registry =
+        Array.isArray(pkg.publish) && pkg.publish.length > 0
+          ? pkg.publish[0]
+          : null;
+      publishCandidates.push({
+        name: pkg.name,
+        version: pkg.version,
+        registry,
+      });
     }
     // Sort so matrix output is stable regardless of cargo's feature
     // emission order (currently a BTreeMap, but not contractually so).
@@ -28127,16 +28231,46 @@ function parseMetadata(metadata) {
   }
   return {
     packages,
-    publish,
+    publishCandidates,
     matrix,
     rustVersion: rustVersion ?? "",
     edition: edition ?? "",
   };
 }
 
-function writeOutputs(metadata) {
-  const { packages, publish, matrix, rustVersion, edition } =
+// Filter publish candidates down to those whose local version is strictly
+// newer than the registry version. Packages that aren't on the registry yet
+// are kept (first publish). Network/parse failures are surfaced as warnings
+// and the candidate is skipped, so a transient outage can't accidentally
+// republish an already-published crate.
+async function filterPublishable(candidates, cwd) {
+  const checks = candidates.map(async ({ name, version, registry }) => {
+    let published;
+    try {
+      published = await getPublishedVersion(name, cwd, registry);
+    } catch (err) {
+      (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .warning */ .$e)(`${name}: cargo info failed (${err.message}); skipping`);
+      return null;
+    }
+    if (published === null) {
+      (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq)(`${name}: not on registry — including for first publish`);
+      return name;
+    }
+    if (compareSemver(version, published) > 0) {
+      (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq)(`${name}: ${published} → ${version} (publishable)`);
+      return name;
+    }
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq)(`${name}: ${version} <= published ${published} (skipping)`);
+    return null;
+  });
+  const resolved = await Promise.all(checks);
+  return resolved.filter((name) => name !== null);
+}
+
+async function writeOutputs(metadata, cwd) {
+  const { packages, publishCandidates, matrix, rustVersion, edition } =
     parseMetadata(metadata);
+  const publish = await filterPublishable(publishCandidates, cwd);
   (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .setOutput */ .uH)("metadata", JSON.stringify(metadata));
   (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .setOutput */ .uH)("packages", JSON.stringify(packages));
   (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .setOutput */ .uH)("publish", JSON.stringify(publish));
@@ -28149,7 +28283,8 @@ async function run() {
   const manifestPath = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .V4)("manifest-path");
   ensureToolchain(manifestPath);
   const metadata = await runCargoMetadata(manifestPath);
-  writeOutputs(metadata);
+  const cwd = (0,path__WEBPACK_IMPORTED_MODULE_2__.dirname)((0,path__WEBPACK_IMPORTED_MODULE_2__.resolve)(manifestPath));
+  await writeOutputs(metadata, cwd);
 }
 
 
@@ -28164,10 +28299,11 @@ __nccwpck_require__.d(__webpack_exports__, {
   V4: () => (/* binding */ getInput),
   pq: () => (/* binding */ info),
   C1: () => (/* binding */ setFailed),
-  uH: () => (/* binding */ setOutput)
+  uH: () => (/* binding */ setOutput),
+  $e: () => (/* binding */ warning)
 });
 
-// UNUSED EXPORTS: ExitCode, addPath, debug, endGroup, error, exportVariable, getBooleanInput, getIDToken, getMultilineInput, getState, group, isDebug, markdownSummary, notice, platform, saveState, setCommandEcho, setSecret, startGroup, summary, toPlatformPath, toPosixPath, toWin32Path, warning
+// UNUSED EXPORTS: ExitCode, addPath, debug, endGroup, error, exportVariable, getBooleanInput, getIDToken, getMultilineInput, getState, group, isDebug, markdownSummary, notice, platform, saveState, setCommandEcho, setSecret, startGroup, summary, toPlatformPath, toPosixPath, toWin32Path
 
 ;// CONCATENATED MODULE: external "os"
 const external_os_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("os");
@@ -31012,7 +31148,7 @@ function error(message, properties = {}) {
  * @param properties optional properties to add to the annotation.
  */
 function warning(message, properties = {}) {
-    issueCommand('warning', toCommandProperties(properties), message instanceof Error ? message.toString() : message);
+    command_issueCommand('warning', utils_toCommandProperties(properties), message instanceof Error ? message.toString() : message);
 }
 /**
  * Adds a notice issue

--- a/dist/index.js
+++ b/dist/index.js
@@ -28141,12 +28141,16 @@ function parseCargoInfoVersion(stdout) {
 // Run `cargo info <name>` and return the latest published version, or null
 // if the package isn't on the registry yet (first publish). Other failures
 // reject so callers can surface them.
+//
+// `--registry` is *always* passed, defaulting to the built-in `crates-io`
+// alias. Without it, `cargo info` first probes the workspace at `cwd` and
+// returns the *local* crate's version when the name happens to match a
+// workspace member — making `local == published` for every candidate and
+// silently emptying the publish output. With `--registry`, cargo skips the
+// local lookup and queries the named registry directly.
 function getPublishedVersion(pkgName, cwd, registry) {
   return new Promise((resolve, reject) => {
-    const args = ["info", pkgName];
-    if (registry) {
-      args.push("--registry", registry);
-    }
+    const args = ["info", pkgName, "--registry", registry || "crates-io"];
     const cmd = (0,child_process__WEBPACK_IMPORTED_MODULE_1__.spawn)("cargo", args, { cwd });
 
     const stdoutChunks = [];

--- a/dist/index.js
+++ b/dist/index.js
@@ -27976,7 +27976,7 @@ __webpack_async_result__();
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
 /* harmony export */   eF: () => (/* binding */ run)
 /* harmony export */ });
-/* unused harmony exports ensureToolchain, runCargoMetadata, compareSemver, parseCargoInfoVersion, getPublishedVersion, parseMetadata, filterPublishable, writeOutputs */
+/* unused harmony exports ensureToolchain, runCargoMetadata, compareSemver, parseCargoInfoVersion, getPublishedVersion, getMaxPublishedVersion, asyncPool, parseMetadata, filterPublishable, writeOutputs */
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(2698);
 /* harmony import */ var child_process__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(5317);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(6928);
@@ -28148,6 +28148,11 @@ function parseCargoInfoVersion(stdout) {
 // workspace member — making `local == published` for every candidate and
 // silently emptying the publish output. With `--registry`, cargo skips the
 // local lookup and queries the named registry directly.
+//
+// A successful exit with no parseable `version:` line is treated as an
+// error, *not* as "first publish" — if cargo's output format ever drifts,
+// the caller's catch path will skip the candidate (safe default) instead
+// of mass-republishing every crate it can't parse.
 function getPublishedVersion(pkgName, cwd, registry) {
   return new Promise((resolve, reject) => {
     const args = ["info", pkgName, "--registry", registry || "crates-io"];
@@ -28178,9 +28183,61 @@ function getPublishedVersion(pkgName, cwd, registry) {
         );
         return;
       }
-      resolve(parseCargoInfoVersion(stdout));
+      const parsed = parseCargoInfoVersion(stdout);
+      if (parsed === null) {
+        reject(
+          new Error(
+            `cargo info ${pkgName} returned no parseable \`version:\` line`,
+          ),
+        );
+        return;
+      }
+      resolve(parsed);
     });
   });
+}
+
+// Query each registry in `registries` for the package's latest version and
+// return the highest one found (or null if no registry has the crate).
+//
+// `pkg.publish` in Cargo.toml may list multiple registries — the crate is
+// then publishable to any of them. We can't predict which the user will
+// `cargo publish --registry <X>` against, so the conservative answer is
+// "is it newer than every place it could land?". Taking the max and
+// requiring `local > max` prevents emitting a crate that would hit
+// "version already uploaded" on whichever registry the user actually
+// targets.
+async function getMaxPublishedVersion(name, cwd, registries) {
+  let max = null;
+  for (const registry of registries) {
+    const v = await getPublishedVersion(name, cwd, registry);
+    if (v === null) continue;
+    if (max === null || compareSemver(v, max) > 0) max = v;
+  }
+  return max;
+}
+
+// Run `worker(item)` over `items` with at most `limit` concurrent in-flight
+// calls. Preserves input order in the returned array.
+//
+// `cargo info` is cheap CPU-wise but spawns a process and hits the network
+// per call. In a 100-crate workspace, `Promise.all(...)` would launch 100
+// concurrent processes and 100 simultaneous registry requests, which can
+// overwhelm a small runner and trigger rate limits. A small pool keeps
+// resource use predictable while still giving real parallelism.
+async function asyncPool(limit, items, worker) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  const runner = async () => {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      results[i] = await worker(items[i], i);
+    }
+  };
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: workerCount }, runner));
+  return results;
 }
 
 function parseMetadata(metadata) {
@@ -28192,17 +28249,19 @@ function parseMetadata(metadata) {
   for (const pkg of metadata.packages ?? []) {
     packages.push(pkg.name);
     if (isPublishable(pkg)) {
-      // `publish = ["my-registry", ...]` restricts where the crate may go;
-      // pick the first entry as the registry to query. `publish = null`
-      // (unrestricted) maps to the default registry, so leave it unset.
-      const registry =
+      // `publish = ["a", "b", ...]` declares every registry the crate may
+      // be published to. We need to query *all* of them and compare against
+      // the highest version found, since the user picks the target with
+      // `cargo publish --registry <X>` at publish time. `publish = null`
+      // means unrestricted → just the default (`crates-io`).
+      const registries =
         Array.isArray(pkg.publish) && pkg.publish.length > 0
-          ? pkg.publish[0]
-          : null;
+          ? [...pkg.publish]
+          : [null];
       publishCandidates.push({
         name: pkg.name,
         version: pkg.version,
-        registry,
+        registries,
       });
     }
     // Sort so matrix output is stable regardless of cargo's feature
@@ -28242,32 +28301,39 @@ function parseMetadata(metadata) {
   };
 }
 
+// Cap on concurrent `cargo info` invocations. Empirically, ~4 saturates a
+// GitHub-hosted runner without triggering registry rate limits.
+const PUBLISH_CHECK_CONCURRENCY = 4;
+
 // Filter publish candidates down to those whose local version is strictly
-// newer than the registry version. Packages that aren't on the registry yet
-// are kept (first publish). Network/parse failures are surfaced as warnings
-// and the candidate is skipped, so a transient outage can't accidentally
-// republish an already-published crate.
+// newer than the registry version. Packages that aren't on any of their
+// declared registries are kept (first publish). Network/parse failures are
+// surfaced as warnings and the candidate is skipped, so a transient outage
+// can't accidentally republish an already-published crate.
 async function filterPublishable(candidates, cwd) {
-  const checks = candidates.map(async ({ name, version, registry }) => {
-    let published;
-    try {
-      published = await getPublishedVersion(name, cwd, registry);
-    } catch (err) {
-      (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .warning */ .$e)(`${name}: cargo info failed (${err.message}); skipping`);
+  const resolved = await asyncPool(
+    PUBLISH_CHECK_CONCURRENCY,
+    candidates,
+    async ({ name, version, registries }) => {
+      let published;
+      try {
+        published = await getMaxPublishedVersion(name, cwd, registries);
+      } catch (err) {
+        (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .warning */ .$e)(`${name}: cargo info failed (${err.message}); skipping`);
+        return null;
+      }
+      if (published === null) {
+        (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq)(`${name}: not on registry — including for first publish`);
+        return name;
+      }
+      if (compareSemver(version, published) > 0) {
+        (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq)(`${name}: ${published} → ${version} (publishable)`);
+        return name;
+      }
+      (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq)(`${name}: ${version} <= published ${published} (skipping)`);
       return null;
-    }
-    if (published === null) {
-      (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq)(`${name}: not on registry — including for first publish`);
-      return name;
-    }
-    if (compareSemver(version, published) > 0) {
-      (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq)(`${name}: ${published} → ${version} (publishable)`);
-      return name;
-    }
-    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq)(`${name}: ${version} <= published ${published} (skipping)`);
-    return null;
-  });
-  const resolved = await Promise.all(checks);
+    },
+  );
   return resolved.filter((name) => name !== null);
 }
 

--- a/lib.js
+++ b/lib.js
@@ -250,7 +250,7 @@ export async function asyncPool(limit, items, worker) {
     while (true) {
       const i = cursor++;
       if (i >= items.length) return;
-      results[i] = await worker(items[i], i);
+      results[i] = await worker(items[i]);
     }
   };
   const workerCount = Math.max(1, Math.min(limit, items.length));

--- a/lib.js
+++ b/lib.js
@@ -166,6 +166,11 @@ export function parseCargoInfoVersion(stdout) {
 // workspace member — making `local == published` for every candidate and
 // silently emptying the publish output. With `--registry`, cargo skips the
 // local lookup and queries the named registry directly.
+//
+// A successful exit with no parseable `version:` line is treated as an
+// error, *not* as "first publish" — if cargo's output format ever drifts,
+// the caller's catch path will skip the candidate (safe default) instead
+// of mass-republishing every crate it can't parse.
 export function getPublishedVersion(pkgName, cwd, registry) {
   return new Promise((resolve, reject) => {
     const args = ["info", pkgName, "--registry", registry || "crates-io"];
@@ -196,9 +201,61 @@ export function getPublishedVersion(pkgName, cwd, registry) {
         );
         return;
       }
-      resolve(parseCargoInfoVersion(stdout));
+      const parsed = parseCargoInfoVersion(stdout);
+      if (parsed === null) {
+        reject(
+          new Error(
+            `cargo info ${pkgName} returned no parseable \`version:\` line`,
+          ),
+        );
+        return;
+      }
+      resolve(parsed);
     });
   });
+}
+
+// Query each registry in `registries` for the package's latest version and
+// return the highest one found (or null if no registry has the crate).
+//
+// `pkg.publish` in Cargo.toml may list multiple registries — the crate is
+// then publishable to any of them. We can't predict which the user will
+// `cargo publish --registry <X>` against, so the conservative answer is
+// "is it newer than every place it could land?". Taking the max and
+// requiring `local > max` prevents emitting a crate that would hit
+// "version already uploaded" on whichever registry the user actually
+// targets.
+export async function getMaxPublishedVersion(name, cwd, registries) {
+  let max = null;
+  for (const registry of registries) {
+    const v = await getPublishedVersion(name, cwd, registry);
+    if (v === null) continue;
+    if (max === null || compareSemver(v, max) > 0) max = v;
+  }
+  return max;
+}
+
+// Run `worker(item)` over `items` with at most `limit` concurrent in-flight
+// calls. Preserves input order in the returned array.
+//
+// `cargo info` is cheap CPU-wise but spawns a process and hits the network
+// per call. In a 100-crate workspace, `Promise.all(...)` would launch 100
+// concurrent processes and 100 simultaneous registry requests, which can
+// overwhelm a small runner and trigger rate limits. A small pool keeps
+// resource use predictable while still giving real parallelism.
+export async function asyncPool(limit, items, worker) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  const runner = async () => {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      results[i] = await worker(items[i], i);
+    }
+  };
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: workerCount }, runner));
+  return results;
 }
 
 export function parseMetadata(metadata) {
@@ -210,17 +267,19 @@ export function parseMetadata(metadata) {
   for (const pkg of metadata.packages ?? []) {
     packages.push(pkg.name);
     if (isPublishable(pkg)) {
-      // `publish = ["my-registry", ...]` restricts where the crate may go;
-      // pick the first entry as the registry to query. `publish = null`
-      // (unrestricted) maps to the default registry, so leave it unset.
-      const registry =
+      // `publish = ["a", "b", ...]` declares every registry the crate may
+      // be published to. We need to query *all* of them and compare against
+      // the highest version found, since the user picks the target with
+      // `cargo publish --registry <X>` at publish time. `publish = null`
+      // means unrestricted → just the default (`crates-io`).
+      const registries =
         Array.isArray(pkg.publish) && pkg.publish.length > 0
-          ? pkg.publish[0]
-          : null;
+          ? [...pkg.publish]
+          : [null];
       publishCandidates.push({
         name: pkg.name,
         version: pkg.version,
-        registry,
+        registries,
       });
     }
     // Sort so matrix output is stable regardless of cargo's feature
@@ -260,32 +319,39 @@ export function parseMetadata(metadata) {
   };
 }
 
+// Cap on concurrent `cargo info` invocations. Empirically, ~4 saturates a
+// GitHub-hosted runner without triggering registry rate limits.
+const PUBLISH_CHECK_CONCURRENCY = 4;
+
 // Filter publish candidates down to those whose local version is strictly
-// newer than the registry version. Packages that aren't on the registry yet
-// are kept (first publish). Network/parse failures are surfaced as warnings
-// and the candidate is skipped, so a transient outage can't accidentally
-// republish an already-published crate.
+// newer than the registry version. Packages that aren't on any of their
+// declared registries are kept (first publish). Network/parse failures are
+// surfaced as warnings and the candidate is skipped, so a transient outage
+// can't accidentally republish an already-published crate.
 export async function filterPublishable(candidates, cwd) {
-  const checks = candidates.map(async ({ name, version, registry }) => {
-    let published;
-    try {
-      published = await getPublishedVersion(name, cwd, registry);
-    } catch (err) {
-      warning(`${name}: cargo info failed (${err.message}); skipping`);
+  const resolved = await asyncPool(
+    PUBLISH_CHECK_CONCURRENCY,
+    candidates,
+    async ({ name, version, registries }) => {
+      let published;
+      try {
+        published = await getMaxPublishedVersion(name, cwd, registries);
+      } catch (err) {
+        warning(`${name}: cargo info failed (${err.message}); skipping`);
+        return null;
+      }
+      if (published === null) {
+        info(`${name}: not on registry — including for first publish`);
+        return name;
+      }
+      if (compareSemver(version, published) > 0) {
+        info(`${name}: ${published} → ${version} (publishable)`);
+        return name;
+      }
+      info(`${name}: ${version} <= published ${published} (skipping)`);
       return null;
-    }
-    if (published === null) {
-      info(`${name}: not on registry — including for first publish`);
-      return name;
-    }
-    if (compareSemver(version, published) > 0) {
-      info(`${name}: ${published} → ${version} (publishable)`);
-      return name;
-    }
-    info(`${name}: ${version} <= published ${published} (skipping)`);
-    return null;
-  });
-  const resolved = await Promise.all(checks);
+    },
+  );
   return resolved.filter((name) => name !== null);
 }
 

--- a/lib.js
+++ b/lib.js
@@ -1,4 +1,4 @@
-import { getInput, info, setOutput } from "@actions/core";
+import { getInput, info, setOutput, warning } from "@actions/core";
 import { spawn, spawnSync } from "child_process";
 import { dirname, resolve as resolvePath } from "path";
 
@@ -104,16 +104,120 @@ function compareVersion(a, b) {
   return 0;
 }
 
+// Full semver compare per https://semver.org §11. Returns negative if a < b,
+// 0 if equal in precedence, positive if a > b. Build metadata (`+...`) is
+// ignored; prerelease segments (`-...`) are compared per spec: numeric < non-
+// numeric, and a version with a prerelease is lower than the same without.
+export function compareSemver(a, b) {
+  const stripBuild = (v) => v.split("+")[0];
+  const split = (v) => {
+    const s = stripBuild(v);
+    const i = s.indexOf("-");
+    return i === -1
+      ? { main: s, pre: null }
+      : { main: s.slice(0, i), pre: s.slice(i + 1) };
+  };
+  const sa = split(a);
+  const sb = split(b);
+  const parse = (m) => m.split(".").map((p) => parseInt(p, 10) || 0);
+  const av = parse(sa.main);
+  const bv = parse(sb.main);
+  for (let i = 0; i < 3; i++) {
+    const diff = (av[i] ?? 0) - (bv[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  if (sa.pre === null && sb.pre === null) return 0;
+  if (sa.pre === null) return 1;
+  if (sb.pre === null) return -1;
+  const ap = sa.pre.split(".");
+  const bp = sb.pre.split(".");
+  for (let i = 0; i < Math.max(ap.length, bp.length); i++) {
+    if (ap[i] === undefined) return -1;
+    if (bp[i] === undefined) return 1;
+    const aNum = /^\d+$/.test(ap[i]);
+    const bNum = /^\d+$/.test(bp[i]);
+    if (aNum && bNum) {
+      const d = parseInt(ap[i], 10) - parseInt(bp[i], 10);
+      if (d !== 0) return d;
+    } else if (aNum !== bNum) {
+      // Numeric identifiers always have lower precedence than alphanumeric.
+      return aNum ? -1 : 1;
+    } else {
+      const c = ap[i] < bp[i] ? -1 : ap[i] > bp[i] ? 1 : 0;
+      if (c !== 0) return c;
+    }
+  }
+  return 0;
+}
+
+// Pulls the published version from cargo info's stdout.
+export function parseCargoInfoVersion(stdout) {
+  const m = stdout.match(/^version:\s*(\S+)/im);
+  return m ? m[1] : null;
+}
+
+// Run `cargo info <name>` and return the latest published version, or null
+// if the package isn't on the registry yet (first publish). Other failures
+// reject so callers can surface them.
+export function getPublishedVersion(pkgName, cwd, registry) {
+  return new Promise((resolve, reject) => {
+    const args = ["info", pkgName];
+    if (registry) {
+      args.push("--registry", registry);
+    }
+    const cmd = spawn("cargo", args, { cwd });
+
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    cmd.stdout.on("data", (chunk) => stdoutChunks.push(chunk));
+    cmd.stderr.on("data", (chunk) => stderrChunks.push(chunk));
+
+    cmd.on("error", (error) => {
+      reject(new Error(`cargo info failed to spawn: ${error.message}`));
+    });
+
+    cmd.on("close", (code) => {
+      const stdout = Buffer.concat(stdoutChunks).toString();
+      const stderr = Buffer.concat(stderrChunks).toString();
+      if (code !== 0) {
+        if (/could not find/i.test(stderr)) {
+          resolve(null);
+          return;
+        }
+        reject(
+          new Error(
+            `cargo info ${pkgName} failed (exit code ${code})` +
+              (stderr.trim() ? `: ${stderr.trim()}` : ""),
+          ),
+        );
+        return;
+      }
+      resolve(parseCargoInfoVersion(stdout));
+    });
+  });
+}
+
 export function parseMetadata(metadata) {
   const packages = [];
-  const publish = [];
+  const publishCandidates = [];
   const matrix = [];
   let rustVersion = null;
   let edition = null;
   for (const pkg of metadata.packages ?? []) {
     packages.push(pkg.name);
     if (isPublishable(pkg)) {
-      publish.push(pkg.name);
+      // `publish = ["my-registry", ...]` restricts where the crate may go;
+      // pick the first entry as the registry to query. `publish = null`
+      // (unrestricted) maps to the default registry, so leave it unset.
+      const registry =
+        Array.isArray(pkg.publish) && pkg.publish.length > 0
+          ? pkg.publish[0]
+          : null;
+      publishCandidates.push({
+        name: pkg.name,
+        version: pkg.version,
+        registry,
+      });
     }
     // Sort so matrix output is stable regardless of cargo's feature
     // emission order (currently a BTreeMap, but not contractually so).
@@ -145,16 +249,46 @@ export function parseMetadata(metadata) {
   }
   return {
     packages,
-    publish,
+    publishCandidates,
     matrix,
     rustVersion: rustVersion ?? "",
     edition: edition ?? "",
   };
 }
 
-export function writeOutputs(metadata) {
-  const { packages, publish, matrix, rustVersion, edition } =
+// Filter publish candidates down to those whose local version is strictly
+// newer than the registry version. Packages that aren't on the registry yet
+// are kept (first publish). Network/parse failures are surfaced as warnings
+// and the candidate is skipped, so a transient outage can't accidentally
+// republish an already-published crate.
+export async function filterPublishable(candidates, cwd) {
+  const checks = candidates.map(async ({ name, version, registry }) => {
+    let published;
+    try {
+      published = await getPublishedVersion(name, cwd, registry);
+    } catch (err) {
+      warning(`${name}: cargo info failed (${err.message}); skipping`);
+      return null;
+    }
+    if (published === null) {
+      info(`${name}: not on registry — including for first publish`);
+      return name;
+    }
+    if (compareSemver(version, published) > 0) {
+      info(`${name}: ${published} → ${version} (publishable)`);
+      return name;
+    }
+    info(`${name}: ${version} <= published ${published} (skipping)`);
+    return null;
+  });
+  const resolved = await Promise.all(checks);
+  return resolved.filter((name) => name !== null);
+}
+
+export async function writeOutputs(metadata, cwd) {
+  const { packages, publishCandidates, matrix, rustVersion, edition } =
     parseMetadata(metadata);
+  const publish = await filterPublishable(publishCandidates, cwd);
   setOutput("metadata", JSON.stringify(metadata));
   setOutput("packages", JSON.stringify(packages));
   setOutput("publish", JSON.stringify(publish));
@@ -167,5 +301,6 @@ export async function run() {
   const manifestPath = getInput("manifest-path");
   ensureToolchain(manifestPath);
   const metadata = await runCargoMetadata(manifestPath);
-  writeOutputs(metadata);
+  const cwd = dirname(resolvePath(manifestPath));
+  await writeOutputs(metadata, cwd);
 }

--- a/lib.js
+++ b/lib.js
@@ -159,12 +159,16 @@ export function parseCargoInfoVersion(stdout) {
 // Run `cargo info <name>` and return the latest published version, or null
 // if the package isn't on the registry yet (first publish). Other failures
 // reject so callers can surface them.
+//
+// `--registry` is *always* passed, defaulting to the built-in `crates-io`
+// alias. Without it, `cargo info` first probes the workspace at `cwd` and
+// returns the *local* crate's version when the name happens to match a
+// workspace member — making `local == published` for every candidate and
+// silently emptying the publish output. With `--registry`, cargo skips the
+// local lookup and queries the named registry directly.
 export function getPublishedVersion(pkgName, cwd, registry) {
   return new Promise((resolve, reject) => {
-    const args = ["info", pkgName];
-    if (registry) {
-      args.push("--registry", registry);
-    }
+    const args = ["info", pkgName, "--registry", registry || "crates-io"];
     const cmd = spawn("cargo", args, { cwd });
 
     const stdoutChunks = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rust-metadata-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rust-metadata-action",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-metadata-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "GitHub action to retrieve metadata, including crates, features, and other relevant information of the Rust project",
   "keywords": [
     "GitHub",

--- a/tests/fixtures/workspace-mixed/app/Cargo.toml
+++ b/tests/fixtures/workspace-mixed/app/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-name = "app"
+# Prefixed with `rma-fixture-` so the name can't collide with a real crate
+# on crates.io. The new publish-output filter calls `cargo info <name>`,
+# and `app` is already published at 0.6.5 — without the prefix the fixture
+# would be filtered out as "older than registry".
+name = "rma-fixture-app"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.85"

--- a/tests/parse-metadata.test.js
+++ b/tests/parse-metadata.test.js
@@ -1,6 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { compareSemver, parseCargoInfoVersion, parseMetadata } from "../lib.js";
+import {
+  asyncPool,
+  compareSemver,
+  parseCargoInfoVersion,
+  parseMetadata,
+} from "../lib.js";
 
 const baselinePkg = {
   name: "ignored",
@@ -80,7 +85,7 @@ test("publish=null is a publish candidate against the default registry", () => {
     ],
   });
   assert.deepEqual(out.publishCandidates, [
-    { name: "foo", version: "1.2.3", registry: null },
+    { name: "foo", version: "1.2.3", registries: [null] },
   ]);
 });
 
@@ -103,7 +108,30 @@ test("publish=['registry'] (restricted) is a candidate scoped to that registry",
     ],
   });
   assert.deepEqual(out.publishCandidates, [
-    { name: "foo", version: "0.5.0", registry: "my-registry" },
+    { name: "foo", version: "0.5.0", registries: ["my-registry"] },
+  ]);
+});
+
+test("publish=['a','b'] preserves the full registry list", () => {
+  // We can't predict which registry the user will `cargo publish --registry`
+  // against, so the full list flows through and filterPublishable queries
+  // each one (and uses the max version found).
+  const out = parseMetadata({
+    packages: [
+      {
+        ...baselinePkg,
+        name: "foo",
+        publish: ["registry-a", "registry-b"],
+        version: "0.5.0",
+      },
+    ],
+  });
+  assert.deepEqual(out.publishCandidates, [
+    {
+      name: "foo",
+      version: "0.5.0",
+      registries: ["registry-a", "registry-b"],
+    },
   ]);
 });
 
@@ -122,8 +150,8 @@ test("packages output always contains every package, regardless of publish", () 
   });
   assert.deepEqual(out.packages, ["a", "b", "c"]);
   assert.deepEqual(out.publishCandidates, [
-    { name: "a", version: "1.0.0", registry: null },
-    { name: "c", version: "1.0.0", registry: "my-registry" },
+    { name: "a", version: "1.0.0", registries: [null] },
+    { name: "c", version: "1.0.0", registries: ["my-registry"] },
   ]);
 });
 
@@ -241,4 +269,37 @@ test("parseCargoInfoVersion returns null when no version line is present", () =>
 
 test("parseCargoInfoVersion is case-insensitive on the key", () => {
   assert.equal(parseCargoInfoVersion("Version: 0.1.0\n"), "0.1.0");
+});
+
+test("asyncPool preserves input order", async () => {
+  // Reverse-correlate delay with index so a naive implementation that
+  // assigned results in completion order would scramble the output.
+  const items = [0, 1, 2, 3, 4];
+  const out = await asyncPool(2, items, async (i) => {
+    await new Promise((r) => setTimeout(r, (items.length - i) * 5));
+    return i * 10;
+  });
+  assert.deepEqual(out, [0, 10, 20, 30, 40]);
+});
+
+test("asyncPool caps in-flight workers at the limit", async () => {
+  let inFlight = 0;
+  let peak = 0;
+  const items = Array.from({ length: 10 }, (_, i) => i);
+  await asyncPool(3, items, async () => {
+    inFlight++;
+    peak = Math.max(peak, inFlight);
+    await new Promise((r) => setTimeout(r, 5));
+    inFlight--;
+  });
+  assert.ok(peak <= 3, `peak in-flight was ${peak}, expected ≤ 3`);
+});
+
+test("asyncPool handles empty input without spawning workers", async () => {
+  let calls = 0;
+  const out = await asyncPool(4, [], async () => {
+    calls++;
+  });
+  assert.deepEqual(out, []);
+  assert.equal(calls, 0);
 });

--- a/tests/parse-metadata.test.js
+++ b/tests/parse-metadata.test.js
@@ -1,9 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseMetadata } from "../lib.js";
+import { compareSemver, parseCargoInfoVersion, parseMetadata } from "../lib.js";
 
 const baselinePkg = {
   name: "ignored",
+  version: "0.1.0",
   publish: null,
   features: {},
 };
@@ -12,7 +13,7 @@ test("empty workspace yields empty arrays", () => {
   const out = parseMetadata({ packages: [] });
   assert.deepEqual(out, {
     packages: [],
-    publish: [],
+    publishCandidates: [],
     matrix: [],
     rustVersion: "",
     edition: "",
@@ -23,7 +24,7 @@ test("missing packages key yields empty arrays", () => {
   const out = parseMetadata({});
   assert.deepEqual(out, {
     packages: [],
-    publish: [],
+    publishCandidates: [],
     matrix: [],
     rustVersion: "",
     edition: "",
@@ -72,37 +73,58 @@ test("matrix entries are sorted alphabetically by feature name", () => {
   ]);
 });
 
-test("publish=null is publishable", () => {
+test("publish=null is a publish candidate against the default registry", () => {
   const out = parseMetadata({
-    packages: [{ ...baselinePkg, name: "foo", publish: null }],
+    packages: [
+      { ...baselinePkg, name: "foo", publish: null, version: "1.2.3" },
+    ],
   });
-  assert.deepEqual(out.publish, ["foo"]);
+  assert.deepEqual(out.publishCandidates, [
+    { name: "foo", version: "1.2.3", registry: null },
+  ]);
 });
 
-test("publish=[] (i.e. publish = false in Cargo.toml) is NOT publishable", () => {
+test("publish=[] (i.e. publish = false in Cargo.toml) is NOT a candidate", () => {
   const out = parseMetadata({
     packages: [{ ...baselinePkg, name: "foo", publish: [] }],
   });
-  assert.deepEqual(out.publish, []);
+  assert.deepEqual(out.publishCandidates, []);
 });
 
-test("publish=['registry'] (restricted) is still publishable", () => {
+test("publish=['registry'] (restricted) is a candidate scoped to that registry", () => {
   const out = parseMetadata({
-    packages: [{ ...baselinePkg, name: "foo", publish: ["my-registry"] }],
+    packages: [
+      {
+        ...baselinePkg,
+        name: "foo",
+        publish: ["my-registry"],
+        version: "0.5.0",
+      },
+    ],
   });
-  assert.deepEqual(out.publish, ["foo"]);
+  assert.deepEqual(out.publishCandidates, [
+    { name: "foo", version: "0.5.0", registry: "my-registry" },
+  ]);
 });
 
 test("packages output always contains every package, regardless of publish", () => {
   const out = parseMetadata({
     packages: [
-      { ...baselinePkg, name: "a", publish: null },
-      { ...baselinePkg, name: "b", publish: [] },
-      { ...baselinePkg, name: "c", publish: ["my-registry"] },
+      { ...baselinePkg, name: "a", publish: null, version: "1.0.0" },
+      { ...baselinePkg, name: "b", publish: [], version: "1.0.0" },
+      {
+        ...baselinePkg,
+        name: "c",
+        publish: ["my-registry"],
+        version: "1.0.0",
+      },
     ],
   });
   assert.deepEqual(out.packages, ["a", "b", "c"]);
-  assert.deepEqual(out.publish, ["a", "c"]);
+  assert.deepEqual(out.publishCandidates, [
+    { name: "a", version: "1.0.0", registry: null },
+    { name: "c", version: "1.0.0", registry: "my-registry" },
+  ]);
 });
 
 test("rust-version is empty string when no package declares one", () => {
@@ -157,4 +179,66 @@ test("edition returns the max across packages", () => {
 test("edition is empty string for empty workspace", () => {
   const out = parseMetadata({ packages: [] });
   assert.equal(out.edition, "");
+});
+
+test("compareSemver: equal versions return 0", () => {
+  assert.equal(compareSemver("1.2.3", "1.2.3"), 0);
+});
+
+test("compareSemver: patch-level bump is greater", () => {
+  assert.ok(compareSemver("1.2.4", "1.2.3") > 0);
+  assert.ok(compareSemver("1.2.3", "1.2.4") < 0);
+});
+
+test("compareSemver: minor bump beats patch", () => {
+  assert.ok(compareSemver("1.3.0", "1.2.99") > 0);
+});
+
+test("compareSemver: numeric (not lexical) compare on each component", () => {
+  assert.ok(compareSemver("1.10.0", "1.9.0") > 0);
+});
+
+test("compareSemver: missing patch defaults to 0", () => {
+  assert.equal(compareSemver("1.2", "1.2.0"), 0);
+});
+
+test("compareSemver: prerelease is lower than the same release", () => {
+  assert.ok(compareSemver("1.2.3-rc.1", "1.2.3") < 0);
+  assert.ok(compareSemver("1.2.3", "1.2.3-rc.1") > 0);
+});
+
+test("compareSemver: numeric prerelease segments compare numerically", () => {
+  assert.ok(compareSemver("1.0.0-alpha.10", "1.0.0-alpha.2") > 0);
+});
+
+test("compareSemver: numeric prerelease segment ranks below alphanumeric", () => {
+  assert.ok(compareSemver("1.0.0-alpha.1", "1.0.0-alpha.beta") < 0);
+});
+
+test("compareSemver: longer prerelease wins when prefix is equal (per semver §11)", () => {
+  assert.ok(compareSemver("1.0.0-alpha.1", "1.0.0-alpha") > 0);
+});
+
+test("compareSemver: build metadata is ignored", () => {
+  assert.equal(compareSemver("1.2.3+build.5", "1.2.3+build.9"), 0);
+});
+
+test("parseCargoInfoVersion picks up the canonical version line", () => {
+  const stdout = [
+    "    Updating crates.io index",
+    "serde #serialization",
+    "A generic serialization/deserialization framework",
+    "version: 1.0.228",
+    "license: MIT OR Apache-2.0",
+    "",
+  ].join("\n");
+  assert.equal(parseCargoInfoVersion(stdout), "1.0.228");
+});
+
+test("parseCargoInfoVersion returns null when no version line is present", () => {
+  assert.equal(parseCargoInfoVersion("just some unrelated text\n"), null);
+});
+
+test("parseCargoInfoVersion is case-insensitive on the key", () => {
+  assert.equal(parseCargoInfoVersion("Version: 0.1.0\n"), "0.1.0");
 });


### PR DESCRIPTION
## Summary

- `publish` previously listed every crate with `publish != false`, so a `cargo publish -p ${{ matrix.package }}` matrix step would hit "crate version already uploaded" until a human pruned it.
- `parseMetadata` now returns `publishCandidates: [{name, version, registry}]` and a new async `filterPublishable` runs `cargo info <name>` (with `--registry` when scoped) for each candidate, keeping only those whose local version is strictly greater per a full semver §11 compare.
- Crates absent from the registry are kept (first publish); other `cargo info` failures log a `core.warning` and skip the candidate, so a transient outage cannot republish a stale crate.

## Test plan

- [x] `npm test` — 28/28 pass, including new `compareSemver` and `parseCargoInfoVersion` cases.
- [x] `npm run check` — prettier clean.
- [x] `npm run build` — `dist/index.js` rebuilt and committed.
- [ ] Smoke test in a workflow against a multi-crate workspace where one crate is bumped and another isn't; confirm only the bumped crate appears in `publish`.
- [ ] Smoke test against a brand-new crate not yet on crates.io; confirm it appears in `publish` (first-publish path).