### PR TITLE
fix: force NO_COLOR on cargo subprocesses so the parser stops missing colorized version: lines

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28024,7 +28024,7 @@ function runCargoMetadata(manifestPath) {
         "--format-version",
         "1",
       ],
-      { cwd },
+      { cwd, env: plainEnv() },
     );
 
     const stdoutChunks = [];
@@ -28060,6 +28060,15 @@ function runCargoMetadata(manifestPath) {
       }
     });
   });
+}
+
+// Force cargo to emit plain text regardless of the workflow's
+// CARGO_TERM_COLOR setting. We parse stdout ourselves; ANSI escapes wrap
+// the field labels (`\e[1m\e[92mversion:\e[0m 0.6.0`) and break anchored
+// regex matches. NO_COLOR is set too as a belt-and-suspenders for any
+// non-cargo subprocess that might inherit this.
+function plainEnv() {
+  return { ...process.env, CARGO_TERM_COLOR: "never", NO_COLOR: "1" };
 }
 
 // Cargo's `publish` field semantics:
@@ -28132,9 +28141,13 @@ function compareSemver(a, b) {
   return 0;
 }
 
-// Pulls the published version from cargo info's stdout.
+// Pulls the published version from cargo info's stdout. Strips ANSI SGR
+// escapes first — `getPublishedVersion` forces NO_COLOR on the spawn, but
+// the parser stays robust if anything else (e.g. a future caller) feeds it
+// colorized output.
 function parseCargoInfoVersion(stdout) {
-  const m = stdout.match(/^version:\s*(\S+)/im);
+  const plain = stdout.replace(/\x1b\[[0-9;]*m/g, "");
+  const m = plain.match(/^version:\s*(\S+)/im);
   return m ? m[1] : null;
 }
 
@@ -28156,7 +28169,7 @@ function parseCargoInfoVersion(stdout) {
 function getPublishedVersion(pkgName, cwd, registry) {
   return new Promise((resolve, reject) => {
     const args = ["info", pkgName, "--registry", registry || "crates-io"];
-    const cmd = (0,child_process__WEBPACK_IMPORTED_MODULE_1__.spawn)("cargo", args, { cwd });
+    const cmd = (0,child_process__WEBPACK_IMPORTED_MODULE_1__.spawn)("cargo", args, { cwd, env: plainEnv() });
 
     const stdoutChunks = [];
     const stderrChunks = [];

--- a/lib.js
+++ b/lib.js
@@ -42,7 +42,7 @@ export function runCargoMetadata(manifestPath) {
         "--format-version",
         "1",
       ],
-      { cwd },
+      { cwd, env: plainEnv() },
     );
 
     const stdoutChunks = [];
@@ -78,6 +78,15 @@ export function runCargoMetadata(manifestPath) {
       }
     });
   });
+}
+
+// Force cargo to emit plain text regardless of the workflow's
+// CARGO_TERM_COLOR setting. We parse stdout ourselves; ANSI escapes wrap
+// the field labels (`\e[1m\e[92mversion:\e[0m 0.6.0`) and break anchored
+// regex matches. NO_COLOR is set too as a belt-and-suspenders for any
+// non-cargo subprocess that might inherit this.
+function plainEnv() {
+  return { ...process.env, CARGO_TERM_COLOR: "never", NO_COLOR: "1" };
 }
 
 // Cargo's `publish` field semantics:
@@ -150,9 +159,13 @@ export function compareSemver(a, b) {
   return 0;
 }
 
-// Pulls the published version from cargo info's stdout.
+// Pulls the published version from cargo info's stdout. Strips ANSI SGR
+// escapes first — `getPublishedVersion` forces NO_COLOR on the spawn, but
+// the parser stays robust if anything else (e.g. a future caller) feeds it
+// colorized output.
 export function parseCargoInfoVersion(stdout) {
-  const m = stdout.match(/^version:\s*(\S+)/im);
+  const plain = stdout.replace(/\x1b\[[0-9;]*m/g, "");
+  const m = plain.match(/^version:\s*(\S+)/im);
   return m ? m[1] : null;
 }
 
@@ -174,7 +187,7 @@ export function parseCargoInfoVersion(stdout) {
 export function getPublishedVersion(pkgName, cwd, registry) {
   return new Promise((resolve, reject) => {
     const args = ["info", pkgName, "--registry", registry || "crates-io"];
-    const cmd = spawn("cargo", args, { cwd });
+    const cmd = spawn("cargo", args, { cwd, env: plainEnv() });
 
     const stdoutChunks = [];
     const stderrChunks = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rust-metadata-action",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rust-metadata-action",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-metadata-action",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "GitHub action to retrieve metadata, including crates, features, and other relevant information of the Rust project",
   "keywords": [
     "GitHub",

--- a/tests/parse-metadata.test.js
+++ b/tests/parse-metadata.test.js
@@ -271,6 +271,16 @@ test("parseCargoInfoVersion is case-insensitive on the key", () => {
   assert.equal(parseCargoInfoVersion("Version: 0.1.0\n"), "0.1.0");
 });
 
+test("parseCargoInfoVersion strips ANSI escapes from cargo's colorized output", () => {
+  // What `cargo info` emits when CARGO_TERM_COLOR=always is set in env —
+  // the field label is wrapped in SGR codes, so a naive `^version:` regex
+  // would miss it. Reproduces the CI warning seen against sv-tools/roas.
+  const stdout =
+    "\x1b[1m\x1b[92mversion:\x1b[0m 0.6.0\n" +
+    "\x1b[1m\x1b[92mlicense:\x1b[0m MIT\n";
+  assert.equal(parseCargoInfoVersion(stdout), "0.6.0");
+});
+
 test("asyncPool preserves input order", async () => {
   // Reverse-correlate delay with index so a naive implementation that
   // assigned results in completion order would scramble the output.


### PR DESCRIPTION
## Summary

When a workflow sets `CARGO_TERM_COLOR=always` (or the user's env enables it), cargo wraps the field labels in ANSI SGR escapes:

```
\e[1m\e[92mversion:\e[0m 0.6.0
```

The `parseCargoInfoVersion` regex at `lib.js:155` is anchored — `^version:` — so the escape-prefixed line didn't match, `parseCargoInfoVersion` returned `null`, `getPublishedVersion` rejected, and `filterPublishable` logged the warning and conservatively skipped the candidate. Net effect: `roas` (already on crates.io as v0.6.0) silently dropped out of the publish output of every CI job that has `CARGO_TERM_COLOR: always` at the workflow env level. Reproduced locally:

```
$ CARGO_TERM_COLOR=always cargo info roas --registry crates-io | cat -v
...
^[[1m^[[92mversion:^[[0m 0.6.0
```

Observed in https://github.com/sv-tools/roas/actions/runs/25615517617/job/75192714474:

```
Warning: roas: cargo info failed (cargo info roas returned no parseable `version:` line); skipping
```

Fix in two layers:

- New `plainEnv()` helper layers `CARGO_TERM_COLOR=never` and `NO_COLOR=1` over `process.env`. Both `runCargoMetadata` and `getPublishedVersion` now spawn cargo with `env: plainEnv()`, so cargo never emits ANSI escapes for the output we parse, regardless of the calling workflow's preferences.
- `parseCargoInfoVersion` strips ANSI SGR escapes (`\x1b\[[0-9;]*m`) before the regex match — defense-in-depth so the parser stays correct if a future caller bypasses `plainEnv()`.

New unit test feeds the parser the exact colorized `version:` line cargo emits under `CARGO_TERM_COLOR=always`. 33/33 pass; `dist/index.js` rebuilt.

## Test plan

- [x] `npm test` — 33/33 pass, including the new ANSI regression case
- [x] `npm run build` — `dist/index.js` regenerated and committed
- [x] `npm run fmt` — no diff
- [ ] CI green on this PR (Dist freshness check + Fixtures matrix)
- [ ] After merge, re-run a `roas` CI job and confirm the `cargo info failed` warning is gone