### PR TITLE
feat: add per-output exclude inputs (packages / publish / matrix) with strict validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ matrix).
 ## Inputs
 
 - `manifest-path`: Path to `Cargo.toml` (default: `"Cargo.toml"`).
-- `matrix-exclude-packages`: Newline- or comma-separated list of package names to drop from the `matrix` output. Excluded packages still appear in `packages` and `publish` — only matrix rows are suppressed.
-- `matrix-exclude-features`: Newline- or comma-separated list of features to drop from `matrix` rows. Each entry is either `<feature>` (excluded from every package that declares it) or `<package>:<feature>` (scoped to a single package). If every feature of a package ends up excluded, the package contributes no matrix rows — there is no bare `--package=` fallback.
+- `packages-exclude`: Comma-separated list of package names to drop from the `packages` output.
+- `publish-exclude`: Comma-separated list of package names to drop from the `publish` output. Useful for crates that are publishable per Cargo.toml but you never want this workflow to publish (e.g. mirrored or vendored copies).
+- `matrix-exclude-packages`: Comma-separated list of package names to drop from the `matrix` output. Excluded packages may still appear in `packages` and `publish` — only matrix rows are suppressed.
+- `matrix-exclude-features`: Comma-separated list of features to drop from `matrix` rows. Each entry is either `<feature>` (excluded from every package that declares it) or `<package>:<feature>` (scoped to a single package). If every feature of a package ends up excluded, the package contributes no matrix rows — there is no bare `--package=` fallback.
+
+All four `*-exclude*` inputs are independent: each only affects its own output. The action validates every name against the actual `cargo metadata` and **fails** if any excluded package or feature isn't found in the workspace — a typo won't silently widen your matrix or publish set.
 
 ## Outputs
 
@@ -40,14 +44,14 @@ jobs:
       - name: Get Rust metadata
         id: rustmeta
         uses: sv-tools/rust-metadata-action@v1
-        # Optional: skip specific packages or features in the matrix output.
+        # Optional: skip specific packages or features. Each input is a
+        # comma-separated list. Names are validated against cargo metadata —
+        # a typo fails the action.
         # with:
-        #   matrix-exclude-packages: |
-        #     experimental-pkg
-        #     internal-tool
-        #   matrix-exclude-features: |
-        #     unstable
-        #     foo:nightly
+        #   packages-exclude: experimental-pkg
+        #   publish-exclude: vendored-crate
+        #   matrix-exclude-packages: experimental-pkg, internal-tool
+        #   matrix-exclude-features: unstable, foo:nightly
       - name: Show packages
         run: |
           echo "Packages: ${{ steps.rustmeta.outputs.packages }}"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ matrix).
 ## Inputs
 
 - `manifest-path`: Path to `Cargo.toml` (default: `"Cargo.toml"`).
+- `matrix-exclude-packages`: Newline- or comma-separated list of package names to drop from the `matrix` output. Excluded packages still appear in `packages` and `publish` — only matrix rows are suppressed.
+- `matrix-exclude-features`: Newline- or comma-separated list of features to drop from `matrix` rows. Each entry is either `<feature>` (excluded from every package that declares it) or `<package>:<feature>` (scoped to a single package). If every feature of a package ends up excluded, the package contributes no matrix rows — there is no bare `--package=` fallback.
 
 ## Outputs
 
@@ -38,6 +40,14 @@ jobs:
       - name: Get Rust metadata
         id: rustmeta
         uses: sv-tools/rust-metadata-action@v1
+        # Optional: skip specific packages or features in the matrix output.
+        # with:
+        #   matrix-exclude-packages: |
+        #     experimental-pkg
+        #     internal-tool
+        #   matrix-exclude-features: |
+        #     unstable
+        #     foo:nightly
       - name: Show packages
         run: |
           echo "Packages: ${{ steps.rustmeta.outputs.packages }}"

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,14 @@ inputs:
     description: "Path to the project's `Cargo.toml`. The action runs from this file's directory, so any adjacent `rust-toolchain.toml` is honored — its pinned toolchain is installed via `rustup` before metadata is read."
     required: false
     default: "Cargo.toml"
+  matrix-exclude-packages:
+    description: "Newline- or comma-separated list of package names to drop from the `matrix` output. Excluded packages still appear in `packages` and `publish`; only matrix rows are suppressed."
+    required: false
+    default: ""
+  matrix-exclude-features:
+    description: "Newline- or comma-separated list of features to drop from `matrix` rows. Each entry is either `<feature>` (excluded from every package that declares it) or `<package>:<feature>` (scoped to that package). If every feature of a package is excluded, the package contributes no matrix rows at all (no bare `--package=` fallback)."
+    required: false
+    default: ""
 outputs:
   metadata:
     description: "Full `cargo metadata --no-deps` output as a JSON-encoded string. Use `fromJson` in workflow expressions to parse it."

--- a/action.yml
+++ b/action.yml
@@ -8,12 +8,20 @@ inputs:
     description: "Path to the project's `Cargo.toml`. The action runs from this file's directory, so any adjacent `rust-toolchain.toml` is honored — its pinned toolchain is installed via `rustup` before metadata is read."
     required: false
     default: "Cargo.toml"
+  packages-exclude:
+    description: "Comma-separated list of package names to drop from the `packages` output. Independent of the other `*-exclude*` inputs."
+    required: false
+    default: ""
+  publish-exclude:
+    description: "Comma-separated list of package names to drop from the `publish` output. Useful for crates that are publishable per Cargo.toml but you never want this workflow to publish (e.g. mirrored or vendored copies). Independent of the other `*-exclude*` inputs."
+    required: false
+    default: ""
   matrix-exclude-packages:
-    description: "Newline- or comma-separated list of package names to drop from the `matrix` output. Excluded packages still appear in `packages` and `publish`; only matrix rows are suppressed."
+    description: "Comma-separated list of package names to drop from the `matrix` output. Excluded packages may still appear in `packages` and `publish`; only matrix rows are suppressed."
     required: false
     default: ""
   matrix-exclude-features:
-    description: "Newline- or comma-separated list of features to drop from `matrix` rows. Each entry is either `<feature>` (excluded from every package that declares it) or `<package>:<feature>` (scoped to that package). If every feature of a package is excluded, the package contributes no matrix rows at all (no bare `--package=` fallback)."
+    description: "Comma-separated list of features to drop from `matrix` rows. Each entry is either `<feature>` (excluded from every package that declares it) or `<package>:<feature>` (scoped to that package). If every feature of a package is excluded, the package contributes no matrix rows at all (no bare `--package=` fallback)."
     required: false
     default: ""
 outputs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -27976,7 +27976,7 @@ __webpack_async_result__();
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
 /* harmony export */   eF: () => (/* binding */ run)
 /* harmony export */ });
-/* unused harmony exports ensureToolchain, runCargoMetadata, compareSemver, parseCargoInfoVersion, getPublishedVersion, getMaxPublishedVersion, asyncPool, parseMetadata, filterPublishable, writeOutputs */
+/* unused harmony exports ensureToolchain, runCargoMetadata, compareSemver, parseCargoInfoVersion, getPublishedVersion, getMaxPublishedVersion, asyncPool, parseExcludeList, parseExcludeFeatures, parseMetadata, filterPublishable, writeOutputs */
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(2698);
 /* harmony import */ var child_process__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(5317);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(6928);
@@ -28253,7 +28253,46 @@ async function asyncPool(limit, items, worker) {
   return results;
 }
 
-function parseMetadata(metadata) {
+// Split a newline/comma-separated input into trimmed, non-empty entries.
+// Used for the `exclude-packages` and `exclude-features` inputs, both of
+// which accept either form (or a mix) so workflows can use multi-line YAML
+// or a single inline string.
+function parseExcludeList(input) {
+  if (!input) return [];
+  return input
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+// Parse `exclude-features` entries into two buckets:
+//   global    — feature names with no `:` (excluded from every package)
+//   byPackage — `<package>:<feature>` entries grouped by package name
+// Empty package or feature halves (`:foo`, `bar:`) are dropped.
+function parseExcludeFeatures(input) {
+  const global = new Set();
+  const byPackage = new Map();
+  for (const entry of parseExcludeList(input)) {
+    const idx = entry.indexOf(":");
+    if (idx === -1) {
+      global.add(entry);
+      continue;
+    }
+    const pkg = entry.slice(0, idx);
+    const feat = entry.slice(idx + 1);
+    if (!pkg || !feat) continue;
+    if (!byPackage.has(pkg)) byPackage.set(pkg, new Set());
+    byPackage.get(pkg).add(feat);
+  }
+  return { global, byPackage };
+}
+
+function parseMetadata(metadata, options = {}) {
+  const excludedPackages = new Set(options.excludePackages ?? []);
+  const excludedFeatures = options.excludeFeatures ?? {
+    global: new Set(),
+    byPackage: new Map(),
+  };
   const packages = [];
   const publishCandidates = [];
   const matrix = [];
@@ -28277,14 +28316,25 @@ function parseMetadata(metadata) {
         registries,
       });
     }
-    // Sort so matrix output is stable regardless of cargo's feature
-    // emission order (currently a BTreeMap, but not contractually so).
-    const features = Object.keys(pkg.features ?? {}).sort();
-    if (features.length === 0) {
-      matrix.push(`--package=${pkg.name}`);
-    } else {
-      for (const feature of features) {
-        matrix.push(`--package=${pkg.name} --features=${feature}`);
+    // Matrix exclusion is independent of `packages`/`publish` — an excluded
+    // package still ships in those outputs; only its matrix rows are dropped.
+    if (!excludedPackages.has(pkg.name)) {
+      // Sort so matrix output is stable regardless of cargo's feature
+      // emission order (currently a BTreeMap, but not contractually so).
+      const allFeatures = Object.keys(pkg.features ?? {}).sort();
+      const pkgScoped = excludedFeatures.byPackage.get(pkg.name);
+      const features = allFeatures.filter(
+        (f) => !excludedFeatures.global.has(f) && !pkgScoped?.has(f),
+      );
+      if (allFeatures.length === 0) {
+        matrix.push(`--package=${pkg.name}`);
+      } else {
+        // If the package has features but every one of them got excluded,
+        // emit nothing for it — the user said "skip these features", not
+        // "fall back to no-features mode".
+        for (const feature of features) {
+          matrix.push(`--package=${pkg.name} --features=${feature}`);
+        }
       }
     }
     if (pkg.rust_version != null) {
@@ -28350,9 +28400,9 @@ async function filterPublishable(candidates, cwd) {
   return resolved.filter((name) => name !== null);
 }
 
-async function writeOutputs(metadata, cwd) {
+async function writeOutputs(metadata, cwd, options = {}) {
   const { packages, publishCandidates, matrix, rustVersion, edition } =
-    parseMetadata(metadata);
+    parseMetadata(metadata, options);
   const publish = await filterPublishable(publishCandidates, cwd);
   (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .setOutput */ .uH)("metadata", JSON.stringify(metadata));
   (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .setOutput */ .uH)("packages", JSON.stringify(packages));
@@ -28364,10 +28414,14 @@ async function writeOutputs(metadata, cwd) {
 
 async function run() {
   const manifestPath = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .V4)("manifest-path");
+  const excludePackages = parseExcludeList((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .V4)("matrix-exclude-packages"));
+  const excludeFeatures = parseExcludeFeatures(
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .V4)("matrix-exclude-features"),
+  );
   ensureToolchain(manifestPath);
   const metadata = await runCargoMetadata(manifestPath);
   const cwd = (0,path__WEBPACK_IMPORTED_MODULE_2__.dirname)((0,path__WEBPACK_IMPORTED_MODULE_2__.resolve)(manifestPath));
-  await writeOutputs(metadata, cwd);
+  await writeOutputs(metadata, cwd, { excludePackages, excludeFeatures });
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -28506,9 +28506,7 @@ async function run() {
   if (errors.length > 0) {
     // Fail loudly before writing any outputs — a typo in an exclude input
     // would otherwise silently widen the matrix / publish set.
-    throw new Error(
-      "Invalid exclusion inputs:\n  " + errors.join("\n  "),
-    );
+    throw new Error("Invalid exclusion inputs:\n  " + errors.join("\n  "));
   }
   const cwd = (0,path__WEBPACK_IMPORTED_MODULE_2__.dirname)((0,path__WEBPACK_IMPORTED_MODULE_2__.resolve)(manifestPath));
   await writeOutputs(metadata, cwd, options);

--- a/dist/index.js
+++ b/dist/index.js
@@ -27976,7 +27976,7 @@ __webpack_async_result__();
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
 /* harmony export */   eF: () => (/* binding */ run)
 /* harmony export */ });
-/* unused harmony exports ensureToolchain, runCargoMetadata, compareSemver, parseCargoInfoVersion, getPublishedVersion, getMaxPublishedVersion, asyncPool, parseExcludeList, parseExcludeFeatures, parseMetadata, filterPublishable, writeOutputs */
+/* unused harmony exports ensureToolchain, runCargoMetadata, compareSemver, parseCargoInfoVersion, getPublishedVersion, getMaxPublishedVersion, asyncPool, parseExcludeList, parseExcludeFeatures, parseMetadata, filterPublishable, validateExclusions, writeOutputs */
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(2698);
 /* harmony import */ var child_process__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(5317);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(6928);
@@ -28253,14 +28253,14 @@ async function asyncPool(limit, items, worker) {
   return results;
 }
 
-// Split a newline/comma-separated input into trimmed, non-empty entries.
-// Used for the `matrix-exclude-packages` and `matrix-exclude-features`
-// inputs, both of which accept either form (or a mix) so workflows can use
-// multi-line YAML or a single inline string.
+// Split a comma-separated input into trimmed, non-empty entries. Used for
+// every `*-exclude*` input — workflows can write either an inline list
+// (`a,b,c`) or use YAML's folded form to span lines, both flatten the same
+// way after trimming.
 function parseExcludeList(input) {
   if (!input) return [];
   return input
-    .split(/[\n,]/)
+    .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 }
@@ -28288,9 +28288,20 @@ function parseExcludeFeatures(input) {
   return { global, byPackage };
 }
 
+// `options` keys mirror their action input names (camelCased):
+//   packagesExclude        — names dropped from `packages` output
+//   publishExclude         — names dropped from `publish` output
+//   matrixExcludePackages  — names dropped from `matrix` output
+//   matrixExcludeFeatures  — { global, byPackage } features dropped from matrix
+// Each output's exclusion is independent — excluding a package from `matrix`
+// does not remove it from `packages` or `publish`, and so on. Compose them
+// to get the behavior you want. `rust-version`/`edition` are computed from
+// every package regardless of excludes (they describe the workspace).
 function parseMetadata(metadata, options = {}) {
-  const excludedPackages = new Set(options.excludePackages ?? []);
-  const excludedFeatures = options.excludeFeatures ?? {
+  const packagesExclude = new Set(options.packagesExclude ?? []);
+  const publishExclude = new Set(options.publishExclude ?? []);
+  const matrixExcludePackages = new Set(options.matrixExcludePackages ?? []);
+  const matrixExcludeFeatures = options.matrixExcludeFeatures ?? {
     global: new Set(),
     byPackage: new Map(),
   };
@@ -28300,8 +28311,10 @@ function parseMetadata(metadata, options = {}) {
   let rustVersion = null;
   let edition = null;
   for (const pkg of metadata.packages ?? []) {
-    packages.push(pkg.name);
-    if (isPublishable(pkg)) {
+    if (!packagesExclude.has(pkg.name)) {
+      packages.push(pkg.name);
+    }
+    if (isPublishable(pkg) && !publishExclude.has(pkg.name)) {
       // `publish = ["a", "b", ...]` declares every registry the crate may
       // be published to. We need to query *all* of them and compare against
       // the highest version found, since the user picks the target with
@@ -28317,15 +28330,13 @@ function parseMetadata(metadata, options = {}) {
         registries,
       });
     }
-    // Matrix exclusion is independent of `packages`/`publish` — an excluded
-    // package still ships in those outputs; only its matrix rows are dropped.
-    if (!excludedPackages.has(pkg.name)) {
+    if (!matrixExcludePackages.has(pkg.name)) {
       // Sort so matrix output is stable regardless of cargo's feature
       // emission order (currently a BTreeMap, but not contractually so).
       const allFeatures = Object.keys(pkg.features ?? {}).sort();
-      const pkgScoped = excludedFeatures.byPackage.get(pkg.name);
+      const pkgScoped = matrixExcludeFeatures.byPackage.get(pkg.name);
       const features = allFeatures.filter(
-        (f) => !excludedFeatures.global.has(f) && !pkgScoped?.has(f),
+        (f) => !matrixExcludeFeatures.global.has(f) && !pkgScoped?.has(f),
       );
       if (allFeatures.length === 0) {
         matrix.push(`--package=${pkg.name}`);
@@ -28401,6 +28412,66 @@ async function filterPublishable(candidates, cwd) {
   return resolved.filter((name) => name !== null);
 }
 
+// Verify every name listed in the exclude inputs corresponds to a real
+// package / feature in the workspace. Returns an array of error messages —
+// empty if everything resolves. Catches typos like
+// `matrix-exclude-packages: my-crate` (the actual crate is `mycrate`).
+//
+// Validation is strict by design: an exclude input that silently matches
+// nothing tends to mean the workflow author thought they were filtering a
+// crate when they weren't, and the bug shows up months later as
+// "why is this thing being published / tested".
+function validateExclusions(metadata, options = {}) {
+  const pkgs = metadata.packages ?? [];
+  const pkgNames = new Set(pkgs.map((p) => p.name));
+  const featuresByPkg = new Map(
+    pkgs.map((p) => [p.name, new Set(Object.keys(p.features ?? {}))]),
+  );
+  // Union of features across the workspace — for validating bare entries
+  // in `matrix-exclude-features` (which apply globally rather than to a
+  // specific package).
+  const allFeatures = new Set();
+  for (const set of featuresByPkg.values()) {
+    for (const f of set) allFeatures.add(f);
+  }
+  const errors = [];
+  const checkPkgList = (input, names) => {
+    for (const name of names ?? []) {
+      if (!pkgNames.has(name)) {
+        errors.push(`${input}: unknown package "${name}"`);
+      }
+    }
+  };
+  checkPkgList("packages-exclude", options.packagesExclude);
+  checkPkgList("publish-exclude", options.publishExclude);
+  checkPkgList("matrix-exclude-packages", options.matrixExcludePackages);
+  const f = options.matrixExcludeFeatures;
+  if (f) {
+    for (const feat of f.global ?? new Set()) {
+      if (!allFeatures.has(feat)) {
+        errors.push(
+          `matrix-exclude-features: unknown feature "${feat}" — not declared by any package`,
+        );
+      }
+    }
+    for (const [pkg, feats] of f.byPackage ?? new Map()) {
+      if (!pkgNames.has(pkg)) {
+        errors.push(`matrix-exclude-features: unknown package "${pkg}"`);
+        continue;
+      }
+      const decl = featuresByPkg.get(pkg);
+      for (const feat of feats) {
+        if (!decl.has(feat)) {
+          errors.push(
+            `matrix-exclude-features: package "${pkg}" does not declare feature "${feat}"`,
+          );
+        }
+      }
+    }
+  }
+  return errors;
+}
+
 async function writeOutputs(metadata, cwd, options = {}) {
   const { packages, publishCandidates, matrix, rustVersion, edition } =
     parseMetadata(metadata, options);
@@ -28415,14 +28486,32 @@ async function writeOutputs(metadata, cwd, options = {}) {
 
 async function run() {
   const manifestPath = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .V4)("manifest-path");
-  const excludePackages = parseExcludeList((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .V4)("matrix-exclude-packages"));
-  const excludeFeatures = parseExcludeFeatures(
+  const packagesExclude = parseExcludeList((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .V4)("packages-exclude"));
+  const publishExclude = parseExcludeList((0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .V4)("publish-exclude"));
+  const matrixExcludePackages = parseExcludeList(
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .V4)("matrix-exclude-packages"),
+  );
+  const matrixExcludeFeatures = parseExcludeFeatures(
     (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .V4)("matrix-exclude-features"),
   );
   ensureToolchain(manifestPath);
   const metadata = await runCargoMetadata(manifestPath);
+  const options = {
+    packagesExclude,
+    publishExclude,
+    matrixExcludePackages,
+    matrixExcludeFeatures,
+  };
+  const errors = validateExclusions(metadata, options);
+  if (errors.length > 0) {
+    // Fail loudly before writing any outputs — a typo in an exclude input
+    // would otherwise silently widen the matrix / publish set.
+    throw new Error(
+      "Invalid exclusion inputs:\n  " + errors.join("\n  "),
+    );
+  }
   const cwd = (0,path__WEBPACK_IMPORTED_MODULE_2__.dirname)((0,path__WEBPACK_IMPORTED_MODULE_2__.resolve)(manifestPath));
-  await writeOutputs(metadata, cwd, { excludePackages, excludeFeatures });
+  await writeOutputs(metadata, cwd, options);
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -28254,9 +28254,9 @@ async function asyncPool(limit, items, worker) {
 }
 
 // Split a newline/comma-separated input into trimmed, non-empty entries.
-// Used for the `exclude-packages` and `exclude-features` inputs, both of
-// which accept either form (or a mix) so workflows can use multi-line YAML
-// or a single inline string.
+// Used for the `matrix-exclude-packages` and `matrix-exclude-features`
+// inputs, both of which accept either form (or a mix) so workflows can use
+// multi-line YAML or a single inline string.
 function parseExcludeList(input) {
   if (!input) return [];
   return input
@@ -28265,10 +28265,11 @@ function parseExcludeList(input) {
     .filter((s) => s.length > 0);
 }
 
-// Parse `exclude-features` entries into two buckets:
+// Parse `matrix-exclude-features` entries into two buckets:
 //   global    — feature names with no `:` (excluded from every package)
 //   byPackage — `<package>:<feature>` entries grouped by package name
-// Empty package or feature halves (`:foo`, `bar:`) are dropped.
+// Both halves around the `:` are trimmed (so `foo: nightly` matches a
+// `nightly` feature). Empty halves (`:foo`, `bar:`) are dropped.
 function parseExcludeFeatures(input) {
   const global = new Set();
   const byPackage = new Map();
@@ -28278,8 +28279,8 @@ function parseExcludeFeatures(input) {
       global.add(entry);
       continue;
     }
-    const pkg = entry.slice(0, idx);
-    const feat = entry.slice(idx + 1);
+    const pkg = entry.slice(0, idx).trim();
+    const feat = entry.slice(idx + 1).trim();
     if (!pkg || !feat) continue;
     if (!byPackage.has(pkg)) byPackage.set(pkg, new Set());
     byPackage.get(pkg).add(feat);

--- a/lib.js
+++ b/lib.js
@@ -271,14 +271,14 @@ export async function asyncPool(limit, items, worker) {
   return results;
 }
 
-// Split a newline/comma-separated input into trimmed, non-empty entries.
-// Used for the `matrix-exclude-packages` and `matrix-exclude-features`
-// inputs, both of which accept either form (or a mix) so workflows can use
-// multi-line YAML or a single inline string.
+// Split a comma-separated input into trimmed, non-empty entries. Used for
+// every `*-exclude*` input — workflows can write either an inline list
+// (`a,b,c`) or use YAML's folded form to span lines, both flatten the same
+// way after trimming.
 export function parseExcludeList(input) {
   if (!input) return [];
   return input
-    .split(/[\n,]/)
+    .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 }
@@ -306,9 +306,20 @@ export function parseExcludeFeatures(input) {
   return { global, byPackage };
 }
 
+// `options` keys mirror their action input names (camelCased):
+//   packagesExclude        — names dropped from `packages` output
+//   publishExclude         — names dropped from `publish` output
+//   matrixExcludePackages  — names dropped from `matrix` output
+//   matrixExcludeFeatures  — { global, byPackage } features dropped from matrix
+// Each output's exclusion is independent — excluding a package from `matrix`
+// does not remove it from `packages` or `publish`, and so on. Compose them
+// to get the behavior you want. `rust-version`/`edition` are computed from
+// every package regardless of excludes (they describe the workspace).
 export function parseMetadata(metadata, options = {}) {
-  const excludedPackages = new Set(options.excludePackages ?? []);
-  const excludedFeatures = options.excludeFeatures ?? {
+  const packagesExclude = new Set(options.packagesExclude ?? []);
+  const publishExclude = new Set(options.publishExclude ?? []);
+  const matrixExcludePackages = new Set(options.matrixExcludePackages ?? []);
+  const matrixExcludeFeatures = options.matrixExcludeFeatures ?? {
     global: new Set(),
     byPackage: new Map(),
   };
@@ -318,8 +329,10 @@ export function parseMetadata(metadata, options = {}) {
   let rustVersion = null;
   let edition = null;
   for (const pkg of metadata.packages ?? []) {
-    packages.push(pkg.name);
-    if (isPublishable(pkg)) {
+    if (!packagesExclude.has(pkg.name)) {
+      packages.push(pkg.name);
+    }
+    if (isPublishable(pkg) && !publishExclude.has(pkg.name)) {
       // `publish = ["a", "b", ...]` declares every registry the crate may
       // be published to. We need to query *all* of them and compare against
       // the highest version found, since the user picks the target with
@@ -335,15 +348,13 @@ export function parseMetadata(metadata, options = {}) {
         registries,
       });
     }
-    // Matrix exclusion is independent of `packages`/`publish` — an excluded
-    // package still ships in those outputs; only its matrix rows are dropped.
-    if (!excludedPackages.has(pkg.name)) {
+    if (!matrixExcludePackages.has(pkg.name)) {
       // Sort so matrix output is stable regardless of cargo's feature
       // emission order (currently a BTreeMap, but not contractually so).
       const allFeatures = Object.keys(pkg.features ?? {}).sort();
-      const pkgScoped = excludedFeatures.byPackage.get(pkg.name);
+      const pkgScoped = matrixExcludeFeatures.byPackage.get(pkg.name);
       const features = allFeatures.filter(
-        (f) => !excludedFeatures.global.has(f) && !pkgScoped?.has(f),
+        (f) => !matrixExcludeFeatures.global.has(f) && !pkgScoped?.has(f),
       );
       if (allFeatures.length === 0) {
         matrix.push(`--package=${pkg.name}`);
@@ -419,6 +430,66 @@ export async function filterPublishable(candidates, cwd) {
   return resolved.filter((name) => name !== null);
 }
 
+// Verify every name listed in the exclude inputs corresponds to a real
+// package / feature in the workspace. Returns an array of error messages —
+// empty if everything resolves. Catches typos like
+// `matrix-exclude-packages: my-crate` (the actual crate is `mycrate`).
+//
+// Validation is strict by design: an exclude input that silently matches
+// nothing tends to mean the workflow author thought they were filtering a
+// crate when they weren't, and the bug shows up months later as
+// "why is this thing being published / tested".
+export function validateExclusions(metadata, options = {}) {
+  const pkgs = metadata.packages ?? [];
+  const pkgNames = new Set(pkgs.map((p) => p.name));
+  const featuresByPkg = new Map(
+    pkgs.map((p) => [p.name, new Set(Object.keys(p.features ?? {}))]),
+  );
+  // Union of features across the workspace — for validating bare entries
+  // in `matrix-exclude-features` (which apply globally rather than to a
+  // specific package).
+  const allFeatures = new Set();
+  for (const set of featuresByPkg.values()) {
+    for (const f of set) allFeatures.add(f);
+  }
+  const errors = [];
+  const checkPkgList = (input, names) => {
+    for (const name of names ?? []) {
+      if (!pkgNames.has(name)) {
+        errors.push(`${input}: unknown package "${name}"`);
+      }
+    }
+  };
+  checkPkgList("packages-exclude", options.packagesExclude);
+  checkPkgList("publish-exclude", options.publishExclude);
+  checkPkgList("matrix-exclude-packages", options.matrixExcludePackages);
+  const f = options.matrixExcludeFeatures;
+  if (f) {
+    for (const feat of f.global ?? new Set()) {
+      if (!allFeatures.has(feat)) {
+        errors.push(
+          `matrix-exclude-features: unknown feature "${feat}" — not declared by any package`,
+        );
+      }
+    }
+    for (const [pkg, feats] of f.byPackage ?? new Map()) {
+      if (!pkgNames.has(pkg)) {
+        errors.push(`matrix-exclude-features: unknown package "${pkg}"`);
+        continue;
+      }
+      const decl = featuresByPkg.get(pkg);
+      for (const feat of feats) {
+        if (!decl.has(feat)) {
+          errors.push(
+            `matrix-exclude-features: package "${pkg}" does not declare feature "${feat}"`,
+          );
+        }
+      }
+    }
+  }
+  return errors;
+}
+
 export async function writeOutputs(metadata, cwd, options = {}) {
   const { packages, publishCandidates, matrix, rustVersion, edition } =
     parseMetadata(metadata, options);
@@ -433,12 +504,28 @@ export async function writeOutputs(metadata, cwd, options = {}) {
 
 export async function run() {
   const manifestPath = getInput("manifest-path");
-  const excludePackages = parseExcludeList(getInput("matrix-exclude-packages"));
-  const excludeFeatures = parseExcludeFeatures(
+  const packagesExclude = parseExcludeList(getInput("packages-exclude"));
+  const publishExclude = parseExcludeList(getInput("publish-exclude"));
+  const matrixExcludePackages = parseExcludeList(
+    getInput("matrix-exclude-packages"),
+  );
+  const matrixExcludeFeatures = parseExcludeFeatures(
     getInput("matrix-exclude-features"),
   );
   ensureToolchain(manifestPath);
   const metadata = await runCargoMetadata(manifestPath);
+  const options = {
+    packagesExclude,
+    publishExclude,
+    matrixExcludePackages,
+    matrixExcludeFeatures,
+  };
+  const errors = validateExclusions(metadata, options);
+  if (errors.length > 0) {
+    // Fail loudly before writing any outputs — a typo in an exclude input
+    // would otherwise silently widen the matrix / publish set.
+    throw new Error("Invalid exclusion inputs:\n  " + errors.join("\n  "));
+  }
   const cwd = dirname(resolvePath(manifestPath));
-  await writeOutputs(metadata, cwd, { excludePackages, excludeFeatures });
+  await writeOutputs(metadata, cwd, options);
 }

--- a/lib.js
+++ b/lib.js
@@ -271,7 +271,46 @@ export async function asyncPool(limit, items, worker) {
   return results;
 }
 
-export function parseMetadata(metadata) {
+// Split a newline/comma-separated input into trimmed, non-empty entries.
+// Used for the `exclude-packages` and `exclude-features` inputs, both of
+// which accept either form (or a mix) so workflows can use multi-line YAML
+// or a single inline string.
+export function parseExcludeList(input) {
+  if (!input) return [];
+  return input
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+// Parse `exclude-features` entries into two buckets:
+//   global    — feature names with no `:` (excluded from every package)
+//   byPackage — `<package>:<feature>` entries grouped by package name
+// Empty package or feature halves (`:foo`, `bar:`) are dropped.
+export function parseExcludeFeatures(input) {
+  const global = new Set();
+  const byPackage = new Map();
+  for (const entry of parseExcludeList(input)) {
+    const idx = entry.indexOf(":");
+    if (idx === -1) {
+      global.add(entry);
+      continue;
+    }
+    const pkg = entry.slice(0, idx);
+    const feat = entry.slice(idx + 1);
+    if (!pkg || !feat) continue;
+    if (!byPackage.has(pkg)) byPackage.set(pkg, new Set());
+    byPackage.get(pkg).add(feat);
+  }
+  return { global, byPackage };
+}
+
+export function parseMetadata(metadata, options = {}) {
+  const excludedPackages = new Set(options.excludePackages ?? []);
+  const excludedFeatures = options.excludeFeatures ?? {
+    global: new Set(),
+    byPackage: new Map(),
+  };
   const packages = [];
   const publishCandidates = [];
   const matrix = [];
@@ -295,14 +334,25 @@ export function parseMetadata(metadata) {
         registries,
       });
     }
-    // Sort so matrix output is stable regardless of cargo's feature
-    // emission order (currently a BTreeMap, but not contractually so).
-    const features = Object.keys(pkg.features ?? {}).sort();
-    if (features.length === 0) {
-      matrix.push(`--package=${pkg.name}`);
-    } else {
-      for (const feature of features) {
-        matrix.push(`--package=${pkg.name} --features=${feature}`);
+    // Matrix exclusion is independent of `packages`/`publish` — an excluded
+    // package still ships in those outputs; only its matrix rows are dropped.
+    if (!excludedPackages.has(pkg.name)) {
+      // Sort so matrix output is stable regardless of cargo's feature
+      // emission order (currently a BTreeMap, but not contractually so).
+      const allFeatures = Object.keys(pkg.features ?? {}).sort();
+      const pkgScoped = excludedFeatures.byPackage.get(pkg.name);
+      const features = allFeatures.filter(
+        (f) => !excludedFeatures.global.has(f) && !pkgScoped?.has(f),
+      );
+      if (allFeatures.length === 0) {
+        matrix.push(`--package=${pkg.name}`);
+      } else {
+        // If the package has features but every one of them got excluded,
+        // emit nothing for it — the user said "skip these features", not
+        // "fall back to no-features mode".
+        for (const feature of features) {
+          matrix.push(`--package=${pkg.name} --features=${feature}`);
+        }
       }
     }
     if (pkg.rust_version != null) {
@@ -368,9 +418,9 @@ export async function filterPublishable(candidates, cwd) {
   return resolved.filter((name) => name !== null);
 }
 
-export async function writeOutputs(metadata, cwd) {
+export async function writeOutputs(metadata, cwd, options = {}) {
   const { packages, publishCandidates, matrix, rustVersion, edition } =
-    parseMetadata(metadata);
+    parseMetadata(metadata, options);
   const publish = await filterPublishable(publishCandidates, cwd);
   setOutput("metadata", JSON.stringify(metadata));
   setOutput("packages", JSON.stringify(packages));
@@ -382,8 +432,12 @@ export async function writeOutputs(metadata, cwd) {
 
 export async function run() {
   const manifestPath = getInput("manifest-path");
+  const excludePackages = parseExcludeList(getInput("matrix-exclude-packages"));
+  const excludeFeatures = parseExcludeFeatures(
+    getInput("matrix-exclude-features"),
+  );
   ensureToolchain(manifestPath);
   const metadata = await runCargoMetadata(manifestPath);
   const cwd = dirname(resolvePath(manifestPath));
-  await writeOutputs(metadata, cwd);
+  await writeOutputs(metadata, cwd, { excludePackages, excludeFeatures });
 }

--- a/lib.js
+++ b/lib.js
@@ -272,9 +272,9 @@ export async function asyncPool(limit, items, worker) {
 }
 
 // Split a newline/comma-separated input into trimmed, non-empty entries.
-// Used for the `exclude-packages` and `exclude-features` inputs, both of
-// which accept either form (or a mix) so workflows can use multi-line YAML
-// or a single inline string.
+// Used for the `matrix-exclude-packages` and `matrix-exclude-features`
+// inputs, both of which accept either form (or a mix) so workflows can use
+// multi-line YAML or a single inline string.
 export function parseExcludeList(input) {
   if (!input) return [];
   return input
@@ -283,10 +283,11 @@ export function parseExcludeList(input) {
     .filter((s) => s.length > 0);
 }
 
-// Parse `exclude-features` entries into two buckets:
+// Parse `matrix-exclude-features` entries into two buckets:
 //   global    — feature names with no `:` (excluded from every package)
 //   byPackage — `<package>:<feature>` entries grouped by package name
-// Empty package or feature halves (`:foo`, `bar:`) are dropped.
+// Both halves around the `:` are trimmed (so `foo: nightly` matches a
+// `nightly` feature). Empty halves (`:foo`, `bar:`) are dropped.
 export function parseExcludeFeatures(input) {
   const global = new Set();
   const byPackage = new Map();
@@ -296,8 +297,8 @@ export function parseExcludeFeatures(input) {
       global.add(entry);
       continue;
     }
-    const pkg = entry.slice(0, idx);
-    const feat = entry.slice(idx + 1);
+    const pkg = entry.slice(0, idx).trim();
+    const feat = entry.slice(idx + 1).trim();
     if (!pkg || !feat) continue;
     if (!byPackage.has(pkg)) byPackage.set(pkg, new Set());
     byPackage.get(pkg).add(feat);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rust-metadata-action",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rust-metadata-action",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-metadata-action",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "GitHub action to retrieve metadata, including crates, features, and other relevant information of the Rust project",
   "keywords": [
     "GitHub",

--- a/tests/parse-metadata.test.js
+++ b/tests/parse-metadata.test.js
@@ -4,6 +4,8 @@ import {
   asyncPool,
   compareSemver,
   parseCargoInfoVersion,
+  parseExcludeFeatures,
+  parseExcludeList,
   parseMetadata,
 } from "../lib.js";
 
@@ -312,4 +314,152 @@ test("asyncPool handles empty input without spawning workers", async () => {
   });
   assert.deepEqual(out, []);
   assert.equal(calls, 0);
+});
+
+test("parseExcludeList splits on newlines and commas, trims, drops empties", () => {
+  assert.deepEqual(parseExcludeList(""), []);
+  assert.deepEqual(parseExcludeList("foo"), ["foo"]);
+  assert.deepEqual(parseExcludeList("foo,bar"), ["foo", "bar"]);
+  assert.deepEqual(parseExcludeList("  foo  ,  bar  "), ["foo", "bar"]);
+  assert.deepEqual(parseExcludeList("foo\nbar\n\nbaz"), ["foo", "bar", "baz"]);
+  assert.deepEqual(parseExcludeList("a, b\nc"), ["a", "b", "c"]);
+});
+
+test("parseExcludeFeatures separates global vs package-scoped entries", () => {
+  const out = parseExcludeFeatures(
+    "unstable\nfoo:experimental,foo:nightly,bar:slow",
+  );
+  assert.deepEqual([...out.global], ["unstable"]);
+  assert.deepEqual([...out.byPackage.get("foo")].sort(), [
+    "experimental",
+    "nightly",
+  ]);
+  assert.deepEqual([...out.byPackage.get("bar")], ["slow"]);
+});
+
+test("parseExcludeFeatures drops malformed entries with empty halves", () => {
+  const out = parseExcludeFeatures(":foo,bar:");
+  assert.equal(out.global.size, 0);
+  assert.equal(out.byPackage.size, 0);
+});
+
+test("excludePackages drops the package's matrix rows but keeps it in packages", () => {
+  const out = parseMetadata(
+    {
+      packages: [
+        { ...baselinePkg, name: "keep" },
+        { ...baselinePkg, name: "drop", features: { a: [], b: [] } },
+      ],
+    },
+    { excludePackages: ["drop"] },
+  );
+  assert.deepEqual(out.packages, ["keep", "drop"]);
+  assert.deepEqual(out.matrix, ["--package=keep"]);
+});
+
+test("excludePackages still allows the package into publishCandidates", () => {
+  const out = parseMetadata(
+    {
+      packages: [
+        { ...baselinePkg, name: "drop", publish: null, version: "1.0.0" },
+      ],
+    },
+    { excludePackages: ["drop"] },
+  );
+  assert.deepEqual(out.publishCandidates, [
+    { name: "drop", version: "1.0.0", registries: [null] },
+  ]);
+  assert.deepEqual(out.matrix, []);
+});
+
+test("excludeFeatures global entry strips that feature from every package", () => {
+  const out = parseMetadata(
+    {
+      packages: [
+        {
+          ...baselinePkg,
+          name: "foo",
+          features: { default: [], unstable: [] },
+        },
+        {
+          ...baselinePkg,
+          name: "bar",
+          features: { stable: [], unstable: [] },
+        },
+      ],
+    },
+    {
+      excludeFeatures: {
+        global: new Set(["unstable"]),
+        byPackage: new Map(),
+      },
+    },
+  );
+  assert.deepEqual(out.matrix, [
+    "--package=foo --features=default",
+    "--package=bar --features=stable",
+  ]);
+});
+
+test("excludeFeatures package-scoped entry only affects the named package", () => {
+  const out = parseMetadata(
+    {
+      packages: [
+        {
+          ...baselinePkg,
+          name: "foo",
+          features: { a: [], b: [] },
+        },
+        {
+          ...baselinePkg,
+          name: "bar",
+          features: { a: [], b: [] },
+        },
+      ],
+    },
+    {
+      excludeFeatures: {
+        global: new Set(),
+        byPackage: new Map([["foo", new Set(["a"])]]),
+      },
+    },
+  );
+  assert.deepEqual(out.matrix, [
+    "--package=foo --features=b",
+    "--package=bar --features=a",
+    "--package=bar --features=b",
+  ]);
+});
+
+test("when every feature of a package is excluded, no rows are emitted for it", () => {
+  // The package originally has features, so we don't fall back to a bare
+  // `--package=foo` row — the user said "skip these features", not "fall
+  // back to no-features mode".
+  const out = parseMetadata(
+    {
+      packages: [{ ...baselinePkg, name: "foo", features: { a: [], b: [] } }],
+    },
+    {
+      excludeFeatures: {
+        global: new Set(["a", "b"]),
+        byPackage: new Map(),
+      },
+    },
+  );
+  assert.deepEqual(out.matrix, []);
+  assert.deepEqual(out.packages, ["foo"]);
+});
+
+test("parseMetadata with no options behaves identically to the default case", () => {
+  // Ensures the new options arg is fully backwards compatible: omitting it
+  // should produce exactly the same output as before.
+  const data = {
+    packages: [
+      { ...baselinePkg, name: "foo", features: { a: [] } },
+      { ...baselinePkg, name: "bar" },
+    ],
+  };
+  const a = parseMetadata(data);
+  const b = parseMetadata(data, {});
+  assert.deepEqual(a, b);
 });

--- a/tests/parse-metadata.test.js
+++ b/tests/parse-metadata.test.js
@@ -343,6 +343,14 @@ test("parseExcludeFeatures drops malformed entries with empty halves", () => {
   assert.equal(out.byPackage.size, 0);
 });
 
+test("parseExcludeFeatures trims whitespace around the package:feature split", () => {
+  // Common YAML shapes: `foo: nightly` or `foo : nightly` — the per-half
+  // trim ensures the parsed names match real package/feature names exactly.
+  const out = parseExcludeFeatures("foo: nightly\n bar :  slow ");
+  assert.deepEqual([...out.byPackage.get("foo")], ["nightly"]);
+  assert.deepEqual([...out.byPackage.get("bar")], ["slow"]);
+});
+
 test("excludePackages drops the package's matrix rows but keeps it in packages", () => {
   const out = parseMetadata(
     {

--- a/tests/parse-metadata.test.js
+++ b/tests/parse-metadata.test.js
@@ -7,6 +7,7 @@ import {
   parseExcludeFeatures,
   parseExcludeList,
   parseMetadata,
+  validateExclusions,
 } from "../lib.js";
 
 const baselinePkg = {
@@ -316,18 +317,23 @@ test("asyncPool handles empty input without spawning workers", async () => {
   assert.equal(calls, 0);
 });
 
-test("parseExcludeList splits on newlines and commas, trims, drops empties", () => {
+test("parseExcludeList splits on commas, trims, drops empties", () => {
   assert.deepEqual(parseExcludeList(""), []);
   assert.deepEqual(parseExcludeList("foo"), ["foo"]);
   assert.deepEqual(parseExcludeList("foo,bar"), ["foo", "bar"]);
   assert.deepEqual(parseExcludeList("  foo  ,  bar  "), ["foo", "bar"]);
-  assert.deepEqual(parseExcludeList("foo\nbar\n\nbaz"), ["foo", "bar", "baz"]);
-  assert.deepEqual(parseExcludeList("a, b\nc"), ["a", "b", "c"]);
+  assert.deepEqual(parseExcludeList("foo,,bar,,,baz"), ["foo", "bar", "baz"]);
+});
+
+test("parseExcludeList does NOT split on newlines (commas only)", () => {
+  // A multi-line YAML string lands here as a single entry — that's by
+  // design now. Workflows must use commas to delimit.
+  assert.deepEqual(parseExcludeList("foo\nbar"), ["foo\nbar"]);
 });
 
 test("parseExcludeFeatures separates global vs package-scoped entries", () => {
   const out = parseExcludeFeatures(
-    "unstable\nfoo:experimental,foo:nightly,bar:slow",
+    "unstable,foo:experimental,foo:nightly,bar:slow",
   );
   assert.deepEqual([...out.global], ["unstable"]);
   assert.deepEqual([...out.byPackage.get("foo")].sort(), [
@@ -346,12 +352,57 @@ test("parseExcludeFeatures drops malformed entries with empty halves", () => {
 test("parseExcludeFeatures trims whitespace around the package:feature split", () => {
   // Common YAML shapes: `foo: nightly` or `foo : nightly` — the per-half
   // trim ensures the parsed names match real package/feature names exactly.
-  const out = parseExcludeFeatures("foo: nightly\n bar :  slow ");
+  const out = parseExcludeFeatures("foo: nightly, bar :  slow ");
   assert.deepEqual([...out.byPackage.get("foo")], ["nightly"]);
   assert.deepEqual([...out.byPackage.get("bar")], ["slow"]);
 });
 
-test("excludePackages drops the package's matrix rows but keeps it in packages", () => {
+test("packagesExclude drops names from the packages output only", () => {
+  const out = parseMetadata(
+    {
+      packages: [
+        { ...baselinePkg, name: "keep", publish: null, version: "1.0.0" },
+        {
+          ...baselinePkg,
+          name: "hide",
+          publish: null,
+          version: "1.0.0",
+          features: { f: [] },
+        },
+      ],
+    },
+    { packagesExclude: ["hide"] },
+  );
+  // Dropped from `packages`, but `publish` and `matrix` are independent.
+  assert.deepEqual(out.packages, ["keep"]);
+  assert.deepEqual(
+    out.publishCandidates.map((c) => c.name),
+    ["keep", "hide"],
+  );
+  assert.deepEqual(out.matrix, [
+    "--package=keep",
+    "--package=hide --features=f",
+  ]);
+});
+
+test("publishExclude drops names from publishCandidates only", () => {
+  const out = parseMetadata(
+    {
+      packages: [
+        { ...baselinePkg, name: "keep", publish: null, version: "1.0.0" },
+        { ...baselinePkg, name: "vendored", publish: null, version: "1.0.0" },
+      ],
+    },
+    { publishExclude: ["vendored"] },
+  );
+  assert.deepEqual(out.packages, ["keep", "vendored"]);
+  assert.deepEqual(out.publishCandidates, [
+    { name: "keep", version: "1.0.0", registries: [null] },
+  ]);
+  assert.deepEqual(out.matrix, ["--package=keep", "--package=vendored"]);
+});
+
+test("matrixExcludePackages drops the package's matrix rows but keeps it elsewhere", () => {
   const out = parseMetadata(
     {
       packages: [
@@ -359,20 +410,20 @@ test("excludePackages drops the package's matrix rows but keeps it in packages",
         { ...baselinePkg, name: "drop", features: { a: [], b: [] } },
       ],
     },
-    { excludePackages: ["drop"] },
+    { matrixExcludePackages: ["drop"] },
   );
   assert.deepEqual(out.packages, ["keep", "drop"]);
   assert.deepEqual(out.matrix, ["--package=keep"]);
 });
 
-test("excludePackages still allows the package into publishCandidates", () => {
+test("matrixExcludePackages still allows the package into publishCandidates", () => {
   const out = parseMetadata(
     {
       packages: [
         { ...baselinePkg, name: "drop", publish: null, version: "1.0.0" },
       ],
     },
-    { excludePackages: ["drop"] },
+    { matrixExcludePackages: ["drop"] },
   );
   assert.deepEqual(out.publishCandidates, [
     { name: "drop", version: "1.0.0", registries: [null] },
@@ -380,7 +431,7 @@ test("excludePackages still allows the package into publishCandidates", () => {
   assert.deepEqual(out.matrix, []);
 });
 
-test("excludeFeatures global entry strips that feature from every package", () => {
+test("matrixExcludeFeatures global entry strips that feature from every package", () => {
   const out = parseMetadata(
     {
       packages: [
@@ -397,7 +448,7 @@ test("excludeFeatures global entry strips that feature from every package", () =
       ],
     },
     {
-      excludeFeatures: {
+      matrixExcludeFeatures: {
         global: new Set(["unstable"]),
         byPackage: new Map(),
       },
@@ -409,7 +460,7 @@ test("excludeFeatures global entry strips that feature from every package", () =
   ]);
 });
 
-test("excludeFeatures package-scoped entry only affects the named package", () => {
+test("matrixExcludeFeatures package-scoped entry only affects the named package", () => {
   const out = parseMetadata(
     {
       packages: [
@@ -426,7 +477,7 @@ test("excludeFeatures package-scoped entry only affects the named package", () =
       ],
     },
     {
-      excludeFeatures: {
+      matrixExcludeFeatures: {
         global: new Set(),
         byPackage: new Map([["foo", new Set(["a"])]]),
       },
@@ -448,7 +499,7 @@ test("when every feature of a package is excluded, no rows are emitted for it", 
       packages: [{ ...baselinePkg, name: "foo", features: { a: [], b: [] } }],
     },
     {
-      excludeFeatures: {
+      matrixExcludeFeatures: {
         global: new Set(["a", "b"]),
         byPackage: new Map(),
       },
@@ -456,6 +507,98 @@ test("when every feature of a package is excluded, no rows are emitted for it", 
   );
   assert.deepEqual(out.matrix, []);
   assert.deepEqual(out.packages, ["foo"]);
+});
+
+test("validateExclusions accepts inputs that all map to real packages/features", () => {
+  const metadata = {
+    packages: [
+      { ...baselinePkg, name: "foo", features: { default: [], full: [] } },
+      { ...baselinePkg, name: "bar", features: { extra: [] } },
+    ],
+  };
+  const errors = validateExclusions(metadata, {
+    packagesExclude: ["foo"],
+    publishExclude: ["bar"],
+    matrixExcludePackages: ["foo"],
+    matrixExcludeFeatures: {
+      global: new Set(["default"]),
+      byPackage: new Map([["bar", new Set(["extra"])]]),
+    },
+  });
+  assert.deepEqual(errors, []);
+});
+
+test("validateExclusions flags unknown packages in each list", () => {
+  const metadata = {
+    packages: [{ ...baselinePkg, name: "real" }],
+  };
+  const errors = validateExclusions(metadata, {
+    packagesExclude: ["typo-a"],
+    publishExclude: ["typo-b"],
+    matrixExcludePackages: ["typo-c"],
+  });
+  assert.equal(errors.length, 3);
+  assert.ok(
+    errors.some((e) => e.includes("packages-exclude") && e.includes("typo-a")),
+  );
+  assert.ok(
+    errors.some((e) => e.includes("publish-exclude") && e.includes("typo-b")),
+  );
+  assert.ok(
+    errors.some(
+      (e) => e.includes("matrix-exclude-packages") && e.includes("typo-c"),
+    ),
+  );
+});
+
+test("validateExclusions flags global features that no package declares", () => {
+  const metadata = {
+    packages: [{ ...baselinePkg, name: "foo", features: { real: [] } }],
+  };
+  const errors = validateExclusions(metadata, {
+    matrixExcludeFeatures: {
+      global: new Set(["nonexistent"]),
+      byPackage: new Map(),
+    },
+  });
+  assert.equal(errors.length, 1);
+  assert.ok(errors[0].includes("nonexistent"));
+});
+
+test("validateExclusions flags package-scoped feature when the package lacks it", () => {
+  const metadata = {
+    packages: [{ ...baselinePkg, name: "foo", features: { a: [] } }],
+  };
+  const errors = validateExclusions(metadata, {
+    matrixExcludeFeatures: {
+      global: new Set(),
+      byPackage: new Map([["foo", new Set(["b"])]]),
+    },
+  });
+  assert.equal(errors.length, 1);
+  assert.ok(errors[0].includes('package "foo"'));
+  assert.ok(errors[0].includes('feature "b"'));
+});
+
+test("validateExclusions flags unknown package in matrix-exclude-features", () => {
+  const metadata = {
+    packages: [{ ...baselinePkg, name: "foo", features: { a: [] } }],
+  };
+  const errors = validateExclusions(metadata, {
+    matrixExcludeFeatures: {
+      global: new Set(),
+      byPackage: new Map([["bogus", new Set(["a"])]]),
+    },
+  });
+  assert.equal(errors.length, 1);
+  assert.ok(errors[0].includes("matrix-exclude-features"));
+  assert.ok(errors[0].includes('"bogus"'));
+});
+
+test("validateExclusions: empty options produce no errors", () => {
+  const metadata = { packages: [{ ...baselinePkg, name: "foo" }] };
+  assert.deepEqual(validateExclusions(metadata, {}), []);
+  assert.deepEqual(validateExclusions(metadata), []);
 });
 
 test("parseMetadata with no options behaves identically to the default case", () => {


### PR DESCRIPTION
## Summary

Adds four optional `*-exclude*` inputs that let workflows prune any of the three list-style outputs independently, plus strict validation that fails the action if any excluded name isn't real.

### New inputs

| Input | Drops names from | Notes |
|---|---|---|
| `packages-exclude` | `packages` output | |
| `publish-exclude` | `publish` output | Useful for crates that are publishable per `Cargo.toml` but you never want this workflow to publish (vendored / mirrored copies). |
| `matrix-exclude-packages` | `matrix` output | |
| `matrix-exclude-features` | `matrix` output | Each entry is `<feature>` (global) or `<package>:<feature>` (scoped). If every feature of a package is excluded, no rows are emitted for it — no bare `--package=` fallback. |

All four are independent — excluding from one output doesn't cascade to the others. Each input is a single comma-separated list (newlines are not separators).

### Strict validation

A new `validateExclusions()` runs before any output is written. If any name in any of the four inputs doesn't resolve against `cargo metadata`, the action fails with a single aggregated error, e.g.:

```
Invalid exclusion inputs:
  matrix-exclude-packages: unknown package "typo-name"
  matrix-exclude-features: package "foo" does not declare feature "nightly"
```

This catches typos that would otherwise silently widen the matrix or publish set.

### Other changes

- `rust-version` and `edition` outputs are computed from every package regardless of excludes — they describe the workspace as a whole.
- Bumps to `1.2.0`.
- Refreshed `dist/index.js`.

## Test plan

- [x] `npm test` — 52 passing (covers each exclusion input, every validation branch, and a regression that newlines do **not** split entries)
- [x] `npm run build` — `dist/index.js` rebuilt
- [x] `npm run check` — prettier clean
- [ ] Smoke-test against a real workspace via this branch's CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)